### PR TITLE
Custom Date Formats

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/WeatherRecyclerAdapter.java
+++ b/app/src/main/java/cz/martykan/forecastie/WeatherRecyclerAdapter.java
@@ -73,21 +73,6 @@ public class WeatherRecyclerAdapter extends RecyclerView.Adapter<WeatherViewHold
             pressure = pressure*0.750061561303;
         }
 
-        String day = "";
-        if(sp.getBoolean("day", true)) {
-            day = "E ";
-        }
-
-        String dateFormat = "dd.MM.yyyy";
-        if(sp.getBoolean("imperialDate", false)) {
-            dateFormat = "MM/dd/yyyy";
-        }
-
-        Calendar cal = Calendar.getInstance();
-        TimeZone tz = cal.getTimeZone();
-
-        SimpleDateFormat resultFormat = new SimpleDateFormat(day + dateFormat + " - HH:mm");
-        resultFormat.setTimeZone(tz);
         Date date;
         try {
             date = new Date(Long.parseLong(weatherItem.getDate()) * 1000);
@@ -103,7 +88,23 @@ public class WeatherRecyclerAdapter extends RecyclerView.Adapter<WeatherViewHold
             }
         }
 
-        customViewHolder.itemDate.setText(resultFormat.format(date));
+        TimeZone tz = Calendar.getInstance().getTimeZone();
+        String defaultDateFormat = context.getResources().getStringArray(R.array.dateFormatsValues)[0];
+        String dateFormat = sp.getString("dateFormat", defaultDateFormat);
+        System.out.println("dateFormat = " + dateFormat);
+        if ("custom".equals(dateFormat)) {
+            dateFormat = sp.getString("dateFormatCustom", defaultDateFormat);
+        }
+        String dateString;
+        try {
+            SimpleDateFormat resultFormat = new SimpleDateFormat(dateFormat);
+            resultFormat.setTimeZone(tz);
+            dateString = resultFormat.format(date);
+        } catch (IllegalArgumentException e) {
+            dateString = context.getResources().getString(R.string.error_dateFormat);
+        }
+
+        customViewHolder.itemDate.setText(dateString);
         customViewHolder.itemTemperature.setText(temperature.substring(0, temperature.indexOf(".") + 2) + " °"+ sp.getString("unit", "C"));
         if(Float.parseFloat(weatherItem.getRain()) > 0.1){
             customViewHolder.itemDescription.setText(weatherItem.getDescription().substring(0, 1).toUpperCase() + weatherItem.getDescription().substring(1) + " (" + weatherItem.getRain().substring(0, weatherItem.getRain().indexOf(".") + 2) + " mm)");

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -49,4 +49,19 @@
         <item name="12">12</item>
         <item name="24">24</item>
     </string-array>
+
+    <string-array name="dateFormats">
+        <item>Wed 30.12.2015 - 16:00</item>
+        <item>30.12.2015 - 16:00</item>
+        <item>Wed 12/30/2015 - 4:00 PM</item>
+        <item>12/30/2015 - 4:00 PM</item>
+        <item>Custom</item>
+    </string-array>
+    <string-array name="dateFormatsValues">
+        <item>E dd.MM.yyyy - HH:mm</item>
+        <item>dd.MM.yyyy - HH:mm</item>
+        <item>E MM/dd/yyyy - hh:mm a</item>
+        <item>MM/dd/yyyy - hh:mm a</item>
+        <item>custom</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,9 +16,11 @@
 
     <string name="search_title">Search for city</string>
 
-    <string name="setting_imperialDate">Use imperial date format</string>
-    <string name="setting_imperialDate_description">12/31/2001 instead of 31.12.2001</string>
-    <string name="setting_showDay">Show day of the week</string>
+    <string name="error_dateFormat">DATE FORMAT ERROR</string>
+
+    <string name="setting_dateFormat">Date Format</string>
+    <string name="setting_dateFormatCustom">Custom Date Format</string>
+    <string name="setting_dateFormatCustom_summary">If Custom selected above, provide the custom SimpleDateFormat string to be used</string>
     <string name="setting_speedUnits">Speed units</string>
     <string name="setting_tempUnits">Temperature units</string>
     <string name="setting_pressureUnits">Pressure units</string>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -23,16 +23,17 @@
             android:key="pressureUnit"
             android:title="@string/setting_pressureUnits" />
 
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="imperialDate"
-            android:summary="@string/setting_imperialDate_description"
-            android:title="@string/setting_imperialDate" />
+        <ListPreference
+            android:defaultValue="E dd.MM.yyyy - HH:mm"
+            android:entries="@array/dateFormats"
+            android:entryValues="@array/dateFormatsValues"
+            android:key="dateFormat"
+            android:title="@string/setting_dateFormat" />
 
-        <CheckBoxPreference
-            android:defaultValue="true"
-            android:key="day"
-            android:title="@string/setting_showDay" />
+        <EditTextPreference
+            android:key="dateFormatCustom"
+            android:title="@string/setting_dateFormatCustom"
+            android:summary="@string/setting_dateFormatCustom_summary" />
 
         <ListPreference
             android:defaultValue="1"


### PR DESCRIPTION
**tl;dr** This changes the way date formatting is handled, adding a new preference that allows selecting between different pre-written date formats as well as providing one's own custom format string. This allows the user to decide how to display the dates & times in any number of ways per their individual tastes. Note: this requires an update to the translations.

See **Motivation** below if you're interested.
Note: the changes included here need Translation work, see **What Still Needs To Be Done** for details.

For licensing purposes: the code and text provided are Copyright (c) 2016 icasdri, and released as free software. You can redistribute and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.

## The Changes
1. Remove the two existing date formatting preferences: namely *Imperial Dates* and *Show Day of Week*
2. Add a new *Date Format* preference which provides a list of date formats (that cover all the possibilities of the old *Imperial Dates* and *Show Day of Week*) and also includes a *Custom* option.
3. Add a new *Custom Date Format* preference, which takes a [SimpleDateFormat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) string -- this string is used if the *Custom* option is selected above.
4. Update logic in `WeatherRecyclerAdapter` accordingly, as well as values in `strings.xml` and `arrays.xml`. An error message is displayed (in place of an actual formatted date) if the custom format string provided by the user is not valid.

These changes have been tested to work on a real device running Android 5.0.1

## What Still Needs To Be Done
Translations. I have only modified the English `strings.xml`, as such, other languages will not work.
The following newly-added strings (followed by their current English values) need to be translated: 

    <string name="error_dateFormat">DATE FORMAT ERROR</string>
    <string name="setting_dateFormat">Date Format</string>
    <string name="setting_dateFormatCustom">Custom Date Format</string>
    <string name="setting_dateFormatCustom_summary">If Custom selected above, provide the custom SimpleDateFormat string to be used</string>
Additionally, the old `setting_imperialDate`, `setting_imperialDate_description`, and `setting_showDay` need to be removed (this has already been done in the English `strings.xml`)

## Motivation
First of all, I would like to give my thanks to all the devs that have contributed so far for this open-source, simple, and intuitive weather app. 

In using the app, I encountered the wish to display times in AM/PM format -- I live in the U.S. and I'll admit, we tell time weird :). **Forecastie** already has two options in its Settings concerning the display of dates & time in the long term forecast: namely the *Imperial Dates* and *Show Day of Week* options -- however, obviously none of these concern my issue. Instead of cluttering the Settings with even more date formatting options, I am pull-requesting a change that allows for the use of any arbitrary format string, both replacing and extending the existing options. I have since found a rather short format string that I now use (for the curious, it is `E - hh:mm a` = "Wed. - 01:00 PM")