### PR TITLE
Differentiating Days by Background Color (tinting)

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/Weather.java
+++ b/app/src/main/java/cz/martykan/forecastie/Weather.java
@@ -91,12 +91,18 @@ public class Weather {
     }
 
     public void setDate(String dateString) {
-        SimpleDateFormat inputFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH);
         try {
-            setDate(inputFormat.parse(dateString));
+            setDate(new Date(Long.parseLong(dateString) * 1000));
         }
-        catch (ParseException e2) {
-            e2.printStackTrace();
+        catch (Exception e) {
+            SimpleDateFormat inputFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH);
+            try {
+                setDate(inputFormat.parse(dateString));
+            }
+            catch (ParseException e2) {
+                setDate(new Date()); // make the error somewhat obvious
+                e2.printStackTrace();
+            }
         }
     }
 

--- a/app/src/main/java/cz/martykan/forecastie/Weather.java
+++ b/app/src/main/java/cz/martykan/forecastie/Weather.java
@@ -1,9 +1,15 @@
 package cz.martykan.forecastie;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+
 public class Weather {
     private String city;
     private String country;
-    private String date;
+    private Date date;
     private String temperature;
     private String description;
     private String wind;
@@ -80,12 +86,40 @@ public class Weather {
         this.icon = icon;
     }
 
-    public String getDate() {
-        return date;
+    public Date getDate(){
+        return this.date;
     }
 
-    public void setDate(String date) {
+    public void setDate(String dateString) {
+        SimpleDateFormat inputFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH);
+        try {
+            setDate(inputFormat.parse(dateString));
+        }
+        catch (ParseException e2) {
+            e2.printStackTrace();
+        }
+    }
+
+    public void setDate(Date date) {
         this.date = date;
+    }
+
+    public long getNumDaysFrom(Date initialDate) {
+        Calendar initial = Calendar.getInstance();
+        initial.setTime(initialDate);
+        initial.set(Calendar.MILLISECOND, 0);
+        initial.set(Calendar.SECOND, 0);
+        initial.set(Calendar.MINUTE, 0);
+        initial.set(Calendar.HOUR, 0);
+
+        Calendar me = Calendar.getInstance();
+        me.setTime(this.date);
+        me.set(Calendar.MILLISECOND, 0);
+        me.set(Calendar.SECOND, 0);
+        me.set(Calendar.MINUTE, 0);
+        me.set(Calendar.HOUR, 0);
+
+        return Math.round((me.getTimeInMillis() - initial.getTimeInMillis()) / 86400000.0);
     }
 
     public String getId() {

--- a/app/src/main/java/cz/martykan/forecastie/WeatherRecyclerAdapter.java
+++ b/app/src/main/java/cz/martykan/forecastie/WeatherRecyclerAdapter.java
@@ -89,6 +89,30 @@ public class WeatherRecyclerAdapter extends RecyclerView.Adapter<WeatherViewHold
             dateString = context.getResources().getString(R.string.error_dateFormat);
         }
 
+        if(sp.getBoolean("differentiateDaysByTint", false)) {
+            Date now = new Date();
+            /* Unfortunately, the getColor() that takes a theme (the next commented line) is Android 6.0 only, so we have to do it manually
+             * customViewHolder.itemView.setBackgroundColor(context.getResources().getColor(R.attr.colorTintedBackground, context.getTheme())); */
+            int colorResourceId;
+            if (weatherItem.getNumDaysFrom(now) % 2 == 1) {
+                if(sp.getBoolean("darkTheme", false)) {
+                    colorResourceId = R.color.darkTheme_colorTintedBackground;
+                } else {
+                    colorResourceId = R.color.colorTintedBackground;
+                }
+            } else {
+                /* We must explicitly set things back, because RecyclerView seems to reuse views and
+                 * without restoring back the "normal" color, just about everything gets tinted if we
+                 * scroll a couple of times! */
+                if(sp.getBoolean("darkTheme", false)) {
+                    colorResourceId = R.color.darkTheme_colorBackground;
+                } else {
+                    colorResourceId = R.color.colorBackground;
+                }
+            }
+            customViewHolder.itemView.setBackgroundColor(context.getResources().getColor(colorResourceId));
+        }
+
         customViewHolder.itemDate.setText(dateString);
         customViewHolder.itemTemperature.setText(temperature.substring(0, temperature.indexOf(".") + 2) + " °"+ sp.getString("unit", "C"));
         if(Float.parseFloat(weatherItem.getRain()) > 0.1){

--- a/app/src/main/java/cz/martykan/forecastie/WeatherRecyclerAdapter.java
+++ b/app/src/main/java/cz/martykan/forecastie/WeatherRecyclerAdapter.java
@@ -5,22 +5,12 @@ import android.content.SharedPreferences;
 import android.graphics.Typeface;
 import android.preference.PreferenceManager;
 import android.support.v7.widget.RecyclerView;
-import android.text.Html;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
-import android.widget.TextView;
-import android.widget.Toast;
-
-import java.text.DateFormat;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 import java.util.TimeZone;
 
 public class WeatherRecyclerAdapter extends RecyclerView.Adapter<WeatherViewHolder> {
@@ -76,7 +66,6 @@ public class WeatherRecyclerAdapter extends RecyclerView.Adapter<WeatherViewHold
         TimeZone tz = TimeZone.getDefault();
         String defaultDateFormat = context.getResources().getStringArray(R.array.dateFormatsValues)[0];
         String dateFormat = sp.getString("dateFormat", defaultDateFormat);
-        System.out.println("dateFormat = " + dateFormat);
         if ("custom".equals(dateFormat)) {
             dateFormat = sp.getString("dateFormatCustom", defaultDateFormat);
         }

--- a/app/src/main/java/cz/martykan/forecastie/WeatherRecyclerAdapter.java
+++ b/app/src/main/java/cz/martykan/forecastie/WeatherRecyclerAdapter.java
@@ -73,22 +73,7 @@ public class WeatherRecyclerAdapter extends RecyclerView.Adapter<WeatherViewHold
             pressure = pressure*0.750061561303;
         }
 
-        Date date;
-        try {
-            date = new Date(Long.parseLong(weatherItem.getDate()) * 1000);
-        }
-        catch (Exception e) {
-            date = new Date();
-            SimpleDateFormat inputFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH);
-            try {
-                date = inputFormat.parse(weatherItem.getDate());
-            }
-            catch (ParseException e2) {
-                e2.printStackTrace();
-            }
-        }
-
-        TimeZone tz = Calendar.getInstance().getTimeZone();
+        TimeZone tz = TimeZone.getDefault();
         String defaultDateFormat = context.getResources().getStringArray(R.array.dateFormatsValues)[0];
         String dateFormat = sp.getString("dateFormat", defaultDateFormat);
         System.out.println("dateFormat = " + dateFormat);
@@ -99,7 +84,7 @@ public class WeatherRecyclerAdapter extends RecyclerView.Adapter<WeatherViewHold
         try {
             SimpleDateFormat resultFormat = new SimpleDateFormat(dateFormat);
             resultFormat.setTimeZone(tz);
-            dateString = resultFormat.format(date);
+            dateString = resultFormat.format(weatherItem.getDate());
         } catch (IllegalArgumentException e) {
             dateString = context.getResources().getString(R.string.error_dateFormat);
         }

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <attr name="colorTintedBackground" format="color" />
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,12 @@
     <color name="colorPrimary">#607d8b</color>
     <color name="colorPrimaryDark">#455a64</color>
     <color name="colorAccent">#455a64</color>
+    <color name="colorBackground">#eceff1</color>
+    <color name="colorTintedBackground">#cfd8dc</color>
+
+    <color name="darkTheme_colorPrimary">#37474f</color>
+    <color name="darkTheme_colorPrimaryDark">#263238</color>
+    <color name="darkTheme_colorAccent">@android:color/white</color>
+    <color name="darkTheme_colorBackground">#263238</color>
+    <color name="darkTheme_colorTintedBackground">@android:color/black</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="setting_tempUnits">Temperature units</string>
     <string name="setting_pressureUnits">Pressure units</string>
     <string name="setting_darkTheme">Dark theme</string>
+    <string name="setting_differentiateDaysByTint">Differentiate Days with Color</string>
     <string name="setting_refreshInterval">Background refresh interval</string>
 
     <string name="weather_sunny" translatable="false">&#xf00d;</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,12 +5,14 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorTintedBackground">@color/colorTintedBackground</item>
     </style>
 
     <style name="AppTheme.Dark" parent="Theme.AppCompat">
-        <item name="colorPrimary">#37474f</item>
-        <item name="colorPrimaryDark">#263238</item>
-        <item name="colorAccent">@android:color/white</item>
+        <item name="colorPrimary">@color/darkTheme_colorPrimary</item>
+        <item name="colorPrimaryDark">@color/darkTheme_colorPrimaryDark</item>
+        <item name="colorAccent">@color/darkTheme_colorAccent</item>
+        <item name="colorTintedBackground">@color/darkTheme_colorTintedBackground</item>
         <item name="android:textColorPrimary">@android:color/white</item>
     </style>
 

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -46,5 +46,10 @@
             android:defaultValue="false"
             android:key="darkTheme"
             android:title="@string/setting_darkTheme" />
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="differentiateDaysByTint"
+            android:title="@string/setting_differentiateDaysByTint" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This pull-request contains changes that resolves #22 by differentiating the days in all *longterm* tabs by coloring/tinting adjacent days with alternating background colors (if the user elects to do so in a newly-added preference). Additionally, some code clean-up and refactoring was made to the date logic in `Weather` and `WeatherRecyclerAdapter` to improve readability and avoid logical redundancies.

For licensing purposes: the code and text provided are Copyright (c) 2016 icasdri, and released as free software. You can redistribute and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.

#### Details of the Changes
* Store the actual `Date` object in `Weather` (accessed as `weatherItem` in the Adapter), as opposed to the unparsed string from the JSON data, so that we only have to run the parsing code once. Changed all code calling `getDate()` accordingly. `setDate()` is overloaded to take an unparsed string, so callers of `setDate()` did not have to be changed.
* Implement a `getNumDaysFrom()` method in `Weather` to facilitate the determination of weather a given date has an "even" or "odd" day -- so that we can tint them differently.
* Reorganize `colors.xml` and `styles.xml` (as well as add a `attrs.xml`) so that colors from the normal or dark theme can be easily accessed via `R` from code.
* Add a `differentiateDaysByTint` preference that allows the user to toggle the behavior
* Implement logic in `WeatherRecyclerAdapter` that actually does the alternating tinting by setting the background color on the view
* Call `TimeZone.getDefault()` instead of `Calendar.getInstance().getTimeZone()` in `WeatherRecyclerAdapter`
* Remove unused imports in `WeatherRecyclerAdapter`
* Remove extraneous print statements (that were left behind on accident) in `WeatherRecyclerAdapter`

I've tested these changes on a device running Android 5.0.1.

#### Some Notes on the Changes
The colors used for the dark theme may need to be adjusted. Currently, the tinted background color for the dark theme is pure black, as the default/normal background color in the dark theme is already the darkest available shade in our color scheme in the Material Color Palette (so we can't really get darker than that), and the color one step lighter is used by the today view (meaning it would be flush with the rest of the stuff on the screen, which is also undesirable).

These changes use the just-deprecated (in Android 6) `getColor()` without specifying a theme. This was done in the interest of maintaining compatibility with KitKat and Lollipop (I tried using the newer `getColor()` that specifies a theme, and it wouldn't run!) However, a future transition to the new API should be pretty trivial as the necessary changes in `attrs.xml` and `styles.xml` were already made, and I've left code using the new API in the comments above the current implementation.

**These changes require additional translations**, namely for the newly added `differentiateDaysByTint` preference. The relevant string is:

    <string name="setting_differentiateDaysByTint">Differentiate Days with Color</string>

