### PR TITLE
Dynamically render date format options in settings

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/SettingsActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/SettingsActivity.java
@@ -4,7 +4,11 @@ import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.os.Bundle;
+import android.preference.EditTextPreference;
+import android.preference.ListPreference;
+import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceManager;
 import android.support.v7.widget.Toolbar;
@@ -13,7 +17,13 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.LinearLayout;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 public class SettingsActivity extends PreferenceActivity {
+
+    // Thursday 2016-01-14 16:00:00
+    Date SAMPLE_DATE = new Date(1452805200000l);
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -36,6 +46,39 @@ public class SettingsActivity extends PreferenceActivity {
         });
 
         addPreferencesFromResource(R.xml.prefs);
+
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
+        Resources res = getResources();
+
+        ListPreference dateFormatPref = (ListPreference) findPreference("dateFormat");
+        String[] dateFormatsValues = res.getStringArray(R.array.dateFormatsValues);
+        String[] dateFormatsEntries = new String[dateFormatsValues.length];
+
+        EditTextPreference customDateFormatPref = (EditTextPreference) findPreference("dateFormatCustom");
+        customDateFormatPref.setDefaultValue(dateFormatsValues[0]);
+
+        SimpleDateFormat sdformat = new SimpleDateFormat();
+        for (int i=0; i<dateFormatsValues.length; i++) {
+            String value = dateFormatsValues[i];
+            if ("custom".equals(value)) {
+                sdformat.applyPattern(sp.getString("dateFormatCustom", dateFormatsValues[0]));
+                String renderedCustom;
+                try {
+                    renderedCustom = sdformat.format(SAMPLE_DATE);
+                } catch (IllegalArgumentException e) {
+                    renderedCustom = res.getString(R.string.error_dateFormat);
+                }
+                dateFormatsEntries[i] = String.format("%s:\n%s",
+                        res.getString(R.string.setting_dateFormatCustom),
+                        renderedCustom);
+            } else {
+                sdformat.applyPattern(value);
+                dateFormatsEntries[i] = sdformat.format(SAMPLE_DATE);
+            }
+        }
+
+        dateFormatPref.setDefaultValue(dateFormatsValues[0]);
+        dateFormatPref.setEntries(dateFormatsEntries);
     }
 
     public void onBackPressed() {

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -20,7 +20,7 @@
     
     <string name="setting_dateFormat">Dataren formatua</string>
     <string name="setting_dateFormatCustom">Datarentzako formatu pertsonalizatua</string>
-    <string name="setting_dateFormatCustom_summary">Goian pertsonalizatua hautatu bada, eman erabiltzeko SimpleDateFormat kate pertsonalizatua/string>
+    <string name="setting_dateFormatCustom_summary">Goian pertsonalizatua hautatu bada, eman erabiltzeko SimpleDateFormat kate pertsonalizatua</string>
     <string name="setting_speedUnits">Abiaduraren unitateak</string>
     <string name="setting_tempUnits">Tenperaturaren unitateak</string>
     <string name="setting_pressureUnits">Presioaren unitateak</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -50,13 +50,6 @@
         <item name="24">24</item>
     </string-array>
 
-    <string-array name="dateFormats">
-        <item>Wed 30.12.2015 - 16:00</item>
-        <item>30.12.2015 - 16:00</item>
-        <item>Wed 12/30/2015 - 4:00 PM</item>
-        <item>12/30/2015 - 4:00 PM</item>
-        <item>Custom</item>
-    </string-array>
     <string-array name="dateFormatsValues">
         <item>E dd.MM.yyyy - HH:mm</item>
         <item>dd.MM.yyyy - HH:mm</item>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -23,9 +23,9 @@
             android:key="pressureUnit"
             android:title="@string/setting_pressureUnits" />
 
+        <!-- dateFormat's (ListPreference) android:defaultValue and android:entries
+             are derived from entryValues dynamically in code in SettingsActivity -->
         <ListPreference
-            android:defaultValue="E dd.MM.yyyy - HH:mm"
-            android:entries="@array/dateFormats"
             android:entryValues="@array/dateFormatsValues"
             android:key="dateFormat"
             android:title="@string/setting_dateFormat" />


### PR DESCRIPTION
This pull-request changes how the date format options in settings are displayed. Instead of housing static locale-specific displays in `arrays.xml` (e.g. the static strings "Custom" and "Wed 30.12.2015 - 16:00"), we now dynamically render each option's name so that we can:

1. Pick up on locale-specific differences like the differences in the name of the day-of-week (not all languages call it "Wed"!)
2. Give the user a preview of what their Custom Date Format looks like -- instead of just showing `Custom` in the options, the user would now see `Custom Date Format: Wed - 16:00` (if their Custom Date Format string is set to `E - hh:mm` for example)

Although this pull-request concerns locale differences, it does not require a translations update as it uses existing strings and rendering machinery akin to what is already used in `WeatherRecyclerAdapter`.

Please merge #29 before this one to prevent conflicts as I forgot to rebase :confused:. Or alternatively, don't merge #29, and just merge this one (this contains those changes as well)...

<hr>

The code provided is `Copyright © 2016 icasdri`, and released as free software. You can redistribute and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.