### PR TITLE
Restart MainActivity without PendingIntent to apply theme

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/MainActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/MainActivity.java
@@ -63,13 +63,15 @@ public class MainActivity extends AppCompatActivity {
     ProgressDialog progressDialog;
     int loading = 0;
 
+    boolean darkTheme;
+
     private List<Weather> longTermWeather;
     private List<Weather> longTermTodayWeather;
     private List<Weather> longTermTomorrowWeather;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        boolean darkTheme = false;
+        darkTheme = false;
         if (PreferenceManager.getDefaultSharedPreferences(this).getBoolean("darkTheme", false)) {
             setTheme(R.style.AppTheme_NoActionBar_Dark);
             darkTheme = true;
@@ -133,7 +135,15 @@ public class MainActivity extends AppCompatActivity {
     @Override
     public void onResume() {
         super.onResume();
-        if (isNetworkAvailable()) {
+        boolean darkTheme =
+                PreferenceManager.getDefaultSharedPreferences(this).getBoolean("darkTheme", false);
+        if (darkTheme != this.darkTheme) {
+            // Restart activity to apply theme
+            overridePendingTransition(0, 0);
+            finish();
+            overridePendingTransition(0, 0);
+            startActivity(getIntent());
+        } else if (isNetworkAvailable()) {
             getTodayWeather();
             getLongTermWeather();
         }

--- a/app/src/main/java/cz/martykan/forecastie/SettingsActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/SettingsActivity.java
@@ -1,8 +1,5 @@
 package cz.martykan.forecastie;
 
-import android.app.AlarmManager;
-import android.app.PendingIntent;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Bundle;
@@ -36,12 +33,7 @@ public class SettingsActivity extends PreferenceActivity {
         toolbar.setNavigationOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Intent startActivity = new Intent(getApplicationContext(), MainActivity.class);
-                int pendingIntentId = 123456;
-                PendingIntent pendingIntent = PendingIntent.getActivity(getApplicationContext(), pendingIntentId, startActivity, PendingIntent.FLAG_CANCEL_CURRENT);
-                AlarmManager mgr = (AlarmManager) getSystemService(ALARM_SERVICE);
-                mgr.set(AlarmManager.RTC, System.currentTimeMillis() + 200, pendingIntent);
-                System.exit(0);
+                finish();
             }
         });
 
@@ -79,16 +71,5 @@ public class SettingsActivity extends PreferenceActivity {
 
         dateFormatPref.setDefaultValue(dateFormatsValues[0]);
         dateFormatPref.setEntries(dateFormatsEntries);
-    }
-
-    public void onBackPressed() {
-        super.onBackPressed();
-
-        Intent startActivity = new Intent(getApplicationContext(), MainActivity.class);
-        int pendingIntentId = 123456;
-        PendingIntent pendingIntent = PendingIntent.getActivity(getApplicationContext(), pendingIntentId, startActivity, PendingIntent.FLAG_CANCEL_CURRENT);
-        AlarmManager mgr = (AlarmManager) getSystemService(ALARM_SERVICE);
-        mgr.set(AlarmManager.RTC, System.currentTimeMillis() + 200, pendingIntent);
-        System.exit(0);
     }
 }


### PR DESCRIPTION
The approach with PendingIntent can cause weird behaviour, e.g. it could open the app after the user closed it.
Restarting MainActivity onResume if the theme changed works better for me.