### PR TITLE
Remove non-translatable strings from fa translation (was failing lint)

### DIFF
--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -73,15 +73,6 @@
     <string name="msg_connection_not_available">ارتباطی در دسترسی نیست.</string>
     <string name="msg_city_not_found">شهر مورد مظر وجود ندارد.</string>
 
-    <string name="weather_sunny" translatable="false">&#xf00d;</string>
-    <string name="weather_clear_night" translatable="false">&#xf02e;</string>
-    <string name="weather_foggy" translatable="false">&#xf014;</string>
-    <string name="weather_cloudy" translatable="false">&#xf013;</string>
-    <string name="weather_rainy" translatable="false">&#xf019;</string>
-    <string name="weather_snowy" translatable="false">&#xf01b;</string>
-    <string name="weather_thunder" translatable="false">&#xf01e;</string>
-    <string name="weather_drizzle" translatable="false">&#xf01c;</string>
-
     <string name="wind_direction_north">N</string>
     <string name="wind_direction_north_north_east">NNE</string>
     <string name="wind_direction_north_east">NE</string>


### PR DESCRIPTION
String `weather_thunder`, etc. are icons and are marked as non-translatable, but snuck themselves into the *fa* translation (causing lint errors during build). This fixes it.