### PR TITLE
Fix NPE when city cannot be found on app start

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/MainActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/MainActivity.java
@@ -480,6 +480,11 @@ public class MainActivity extends AppCompatActivity implements LocationListener 
 
             final String code = reader.optString("cod");
             if ("404".equals(code)) {
+                if (longTermWeather == null) {
+                    longTermWeather = new ArrayList<>();
+                    longTermTodayWeather = new ArrayList<>();
+                    longTermTomorrowWeather = new ArrayList<>();
+                }
                 return ParseResult.CITY_NOT_FOUND;
             }
 


### PR DESCRIPTION
The city I had previously selected wasn't available anymore somehow. That's what I got on app start:
java.lang.NullPointerException: Attempt to invoke interface method 'boolean java.util.List.isEmpty()' on a null object reference
    at cz.martykan.forecastie.MainActivity.updateLongTermWeatherUI(MainActivity.java:582)
    at cz.martykan.forecastie.MainActivity.access$700(MainActivity.java:64)
    at cz.martykan.forecastie.MainActivity$LongTermWeatherTask.updateMainUI(MainActivity.java:963)
    at cz.martykan.forecastie.MainActivity$GenericRequestTask.onPostExecute(MainActivity.java:854)
    at cz.martykan.forecastie.MainActivity$GenericRequestTask.onPostExecute(MainActivity.java:756)
    at android.os.AsyncTask.finish(AsyncTask.java:651)
    at android.os.AsyncTask.-wrap1(AsyncTask.java)
    at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:668)
    at android.os.Handler.dispatchMessage(Handler.java:102)
    at android.os.Looper.loop(Looper.java:148)
    at android.app.ActivityThread.main(ActivityThread.java:5458)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)