### PR TITLE
Use network and gps simultaneously to determine location.

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
@@ -722,7 +722,8 @@ public class MainActivity extends AppCompatActivity implements LocationListener 
             progressDialog.show();
             if (locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)) {
                 locationManager.requestLocationUpdates(LocationManager.NETWORK_PROVIDER, 0, 0, this);
-            } else if (locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
+            }
+            if (locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
                 locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0, this);
             }
         }


### PR DESCRIPTION
If only network is used, and you can't get a network location for
some reason (e.g. you don't have an Internet connection), it
should at least try with GPS.