### PR TITLE
Request location only once

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
@@ -744,6 +744,11 @@ public class MainActivity extends AppCompatActivity implements LocationListener 
     @Override
     public void onLocationChanged(Location location) {
         progressDialog.hide();
+        try {
+            locationManager.removeUpdates(this);
+        } catch (SecurityException e) {
+            Log.e("LocationManager", "Error while trying to stop listening for location updates. This is probably a permissions issue", e);
+        }
         Log.i("LOCATION (" + location.getProvider().toUpperCase() + ")", location.getLatitude() + ", " + location.getLongitude());
         double latitude = location.getLatitude();
         double longitude = location.getLongitude();


### PR DESCRIPTION
removeUpdates from LocationManager once the onLocationChanged
method is called (a location could be determined).

I am not sure if it is intended to leave the Listener on or if you just want to get the location once, so this PR might be useless :wink: 