### PR TITLE
Avoid NullPointerException onDestroy

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
@@ -187,10 +187,12 @@ public class MainActivity extends AppCompatActivity implements LocationListener 
         super.onDestroy();
         destroyed = true;
 
-        try {
-            locationManager.removeUpdates(MainActivity.this);
-        } catch (Exception e) {
-            e.printStackTrace();
+        if (locationManager != null) {
+            try {
+                locationManager.removeUpdates(MainActivity.this);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
     }
 


### PR DESCRIPTION
Check that locationManager is not null before trying to
remove location listener updates so that it won't throw a
NullPointerException.