### PR TITLE
Changed default zoom for weater maps

### DIFF
--- a/app/src/main/assets/map.html
+++ b/app/src/main/assets/map.html
@@ -40,7 +40,7 @@
     var map = L.map('map', {
         zoomControl: false,
         attributionControl: false
-    }).setView([getUrlParameter('lon'), getUrlParameter('lat')], 13);
+    }).setView([getUrlParameter('lon'), getUrlParameter('lat')], 7);
 
     map.addLayer(new L.TileLayer("http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
         minZoom: 1,


### PR DESCRIPTION
Default zoom now shows appropriate information. Zoom 13 was too close for the low precision of the data we are looking at.