### PR TITLE
Reduced minimum height of time widget

### DIFF
--- a/app/src/main/res/xml/time_widget.xml
+++ b/app/src/main/res/xml/time_widget.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:minWidth="270dp"
-    android:minHeight="64dp"
+    android:minHeight="50dp"
     android:updatePeriodMillis="1800000"
     android:initialLayout="@layout/time_widget"
-    android:resizeMode="horizontal|vertical"
+    android:resizeMode="vertical"
     android:widgetCategory="home_screen|keyguard"
     android:previewImage="@drawable/widget_preview_time">
 </appwidget-provider>


### PR DESCRIPTION
So that it can have a height of one cell for all screen settings.

See  #184.