### PR TITLE
Issue #176

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
@@ -173,6 +173,13 @@ public class MainActivity extends AppCompatActivity implements LocationListener 
     }
 
     @Override
+    public void onStart() {
+        super.onStart();
+        updateTodayWeatherUI();
+        updateLongTermWeatherUI();
+    }
+
+    @Override
     public void onResume() {
         super.onResume();
         if (getTheme(PreferenceManager.getDefaultSharedPreferences(this).getString("theme", "fresh")) != theme) {


### PR DESCRIPTION
With this change, the main activity interface is updated when it is started. The units are displayed properly right away when user makes changes in settings and comes back to the main activity.