### PR TITLE
Make widget conform to configured theme

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "cz.martykan.forecastie"
-        minSdkVersion 21
+        minSdkVersion 15
         targetSdkVersion 23
         versionCode 20
         versionName "1.6.1"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "cz.martykan.forecastie"
-        minSdkVersion 15
+        minSdkVersion 21
         targetSdkVersion 23
         versionCode 20
         versionName "1.6.1"

--- a/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
@@ -95,7 +95,7 @@ public class MainActivity extends AppCompatActivity implements LocationListener 
     ProgressDialog progressDialog;
 
     int theme;
-    boolean widgetTransparent;
+    private boolean widgetTransparent;
     boolean destroyed = false;
 
     private List<Weather> longTermWeather = new ArrayList<>();

--- a/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
@@ -95,6 +95,7 @@ public class MainActivity extends AppCompatActivity implements LocationListener 
     ProgressDialog progressDialog;
 
     int theme;
+    boolean widgetTransparent;
     boolean destroyed = false;
 
     private List<Weather> longTermWeather = new ArrayList<>();
@@ -114,6 +115,7 @@ public class MainActivity extends AppCompatActivity implements LocationListener 
                 theme == R.style.AppTheme_NoActionBar_Classic_Dark;
         boolean blackTheme = theme == R.style.AppTheme_NoActionBar_Black ||
                 theme == R.style.AppTheme_NoActionBar_Classic_Black;
+        widgetTransparent = prefs.getBoolean("transparentWidget", false);
 
         // Initiate activity
         super.onCreate(savedInstanceState);
@@ -182,7 +184,8 @@ public class MainActivity extends AppCompatActivity implements LocationListener 
     @Override
     public void onResume() {
         super.onResume();
-        if (getTheme(PreferenceManager.getDefaultSharedPreferences(this).getString("theme", "fresh")) != theme) {
+        if (getTheme(PreferenceManager.getDefaultSharedPreferences(this).getString("theme", "fresh")) != theme ||
+                PreferenceManager.getDefaultSharedPreferences(this).getBoolean("transparentWidget", false) != widgetTransparent) {
             // Restart activity to apply theme
             overridePendingTransition(0, 0);
             finish();

--- a/app/src/main/java/cz/martykan/forecastie/activities/SettingsActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/activities/SettingsActivity.java
@@ -100,7 +100,6 @@ public class SettingsActivity extends PreferenceActivity
             case "dateFormatCustom":
                 updateDateFormatList();
                 break;
-            case "transparentWidget":
             case "theme":
                 // Restart activity to apply theme
                 overridePendingTransition(0, 0);
@@ -115,6 +114,7 @@ public class SettingsActivity extends PreferenceActivity
                 break;
             case "apiKey":
                 checkKey(key);
+                break;
         }
     }
 

--- a/app/src/main/java/cz/martykan/forecastie/activities/SettingsActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/activities/SettingsActivity.java
@@ -18,14 +18,12 @@ import android.preference.PreferenceManager;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.Toolbar;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.LinearLayout;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Objects;
 
 import cz.martykan.forecastie.AlarmReceiver;
 import cz.martykan.forecastie.R;

--- a/app/src/main/java/cz/martykan/forecastie/activities/SettingsActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/activities/SettingsActivity.java
@@ -102,6 +102,7 @@ public class SettingsActivity extends PreferenceActivity
             case "dateFormatCustom":
                 updateDateFormatList();
                 break;
+            case "transparentWidget":
             case "theme":
                 // Restart activity to apply theme
                 overridePendingTransition(0, 0);

--- a/app/src/main/java/cz/martykan/forecastie/widgets/AbstractWidgetProvider.java
+++ b/app/src/main/java/cz/martykan/forecastie/widgets/AbstractWidgetProvider.java
@@ -206,6 +206,7 @@ public abstract class AbstractWidgetProvider extends AppWidgetProvider {
                 break;
             default:
                 remoteViews.setInt(R.id.widgetRoot, "setBackgroundResource", R.drawable.widget_card);
+                break;
         }
     }
 

--- a/app/src/main/java/cz/martykan/forecastie/widgets/AbstractWidgetProvider.java
+++ b/app/src/main/java/cz/martykan/forecastie/widgets/AbstractWidgetProvider.java
@@ -13,6 +13,7 @@ import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.preference.PreferenceManager;
 import android.util.Log;
+import android.widget.RemoteViews;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -26,7 +27,6 @@ import cz.martykan.forecastie.models.Weather;
 import cz.martykan.forecastie.utils.UnitConvertor;
 
 public abstract class AbstractWidgetProvider extends AppWidgetProvider {
-
     protected Bitmap getWeatherIcon(String text, Context context) {
         Bitmap myBitmap = Bitmap.createBitmap(256, 256, Bitmap.Config.ARGB_4444);
         Canvas myCanvas = new Canvas(myBitmap);
@@ -155,5 +155,24 @@ public abstract class AbstractWidgetProvider extends AppWidgetProvider {
                 .getAppWidgetIds(new ComponentName(context.getApplicationContext(), widgetClass));
         intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids);
         context.getApplicationContext().sendBroadcast(intent);
+    }
+
+    protected void setTheme(Context context, RemoteViews remoteViews) {
+        String theme = PreferenceManager.getDefaultSharedPreferences(context).getString("theme", "fresh");
+        switch (theme) {
+            case "dark":
+            case "classicdark":
+                remoteViews.setInt(R.id.widgetRoot, "setBackgroundResource", R.drawable.widget_card_dark);
+                break;
+            case "black":
+            case "classicblack":
+                remoteViews.setInt(R.id.widgetRoot, "setBackgroundResource", R.drawable.widget_card_black);
+                break;
+            case "classic":
+                remoteViews.setInt(R.id.widgetRoot, "setBackgroundResource", R.drawable.widget_card_classic);
+                break;
+            default:
+                remoteViews.setInt(R.id.widgetRoot, "setBackgroundResource", R.drawable.widget_card);
+        }
     }
 }

--- a/app/src/main/java/cz/martykan/forecastie/widgets/AbstractWidgetProvider.java
+++ b/app/src/main/java/cz/martykan/forecastie/widgets/AbstractWidgetProvider.java
@@ -1,5 +1,7 @@
 package cz.martykan.forecastie.widgets;
 
+import android.app.AlarmManager;
+import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;
 import android.content.ComponentName;
@@ -11,6 +13,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Typeface;
+import android.os.Build;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.widget.RemoteViews;
@@ -20,13 +23,39 @@ import org.json.JSONObject;
 
 import java.text.DecimalFormat;
 import java.util.Calendar;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
+import cz.martykan.forecastie.BuildConfig;
 import cz.martykan.forecastie.activities.MainActivity;
 import cz.martykan.forecastie.R;
 import cz.martykan.forecastie.models.Weather;
 import cz.martykan.forecastie.utils.UnitConvertor;
 
 public abstract class AbstractWidgetProvider extends AppWidgetProvider {
+    protected static final long DURATION_MINUTE = TimeUnit.SECONDS.toMillis(30);
+    protected static final String ACTION_UPDATE_TIME = "cz.martykan.forecastie.UPDATE_TIME";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (ACTION_UPDATE_TIME.equals(intent.getAction())) {
+            AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
+            ComponentName provider = new ComponentName(context.getPackageName(), getClass().getName());
+            int ids[] = appWidgetManager.getAppWidgetIds(provider);
+            onUpdate(context, appWidgetManager, ids);
+        } else {
+            super.onReceive(context, intent);
+        }
+    }
+
+    @Override
+    public void onDisabled(Context context) {
+        super.onDisabled(context);
+
+        Log.d(this.getClass().getSimpleName(), "Disable updates for this widget");
+        cancelUpdate(context);
+    }
+
     protected Bitmap getWeatherIcon(String text, Context context) {
         Bitmap myBitmap = Bitmap.createBitmap(256, 256, Bitmap.Config.ARGB_4444);
         Canvas myCanvas = new Canvas(myBitmap);
@@ -158,6 +187,10 @@ public abstract class AbstractWidgetProvider extends AppWidgetProvider {
     }
 
     protected void setTheme(Context context, RemoteViews remoteViews) {
+        if (PreferenceManager.getDefaultSharedPreferences(context).getBoolean("transparentWidget", false)){
+            remoteViews.setInt(R.id.widgetRoot, "setBackgroundResource", R.drawable.widget_card_transparent);
+            return;
+        }
         String theme = PreferenceManager.getDefaultSharedPreferences(context).getString("theme", "fresh");
         switch (theme) {
             case "dark":
@@ -174,5 +207,31 @@ public abstract class AbstractWidgetProvider extends AppWidgetProvider {
             default:
                 remoteViews.setInt(R.id.widgetRoot, "setBackgroundResource", R.drawable.widget_card);
         }
+    }
+
+    protected void scheduleNextUpdate(Context context) {
+        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        long now = new Date().getTime();
+        long nextUpdate = now + DURATION_MINUTE - now % DURATION_MINUTE;
+        if (BuildConfig.DEBUG) {
+            Log.v(this.getClass().getSimpleName(), "Next widget update: " +
+                    android.text.format.DateFormat.getTimeFormat(context).format(new Date(nextUpdate)));
+        }
+        if (Build.VERSION.SDK_INT >= 19) {
+            alarmManager.setExact(AlarmManager.RTC, nextUpdate, getTimeIntent(context));
+        } else {
+            alarmManager.set(AlarmManager.RTC, nextUpdate, getTimeIntent(context));
+        }
+    }
+
+    protected void cancelUpdate(Context context) {
+        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        alarmManager.cancel(getTimeIntent(context));
+    }
+
+    protected PendingIntent getTimeIntent(Context context) {
+        Intent intent = new Intent(context, this.getClass());
+        intent.setAction(ACTION_UPDATE_TIME);
+        return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
     }
 }

--- a/app/src/main/java/cz/martykan/forecastie/widgets/ExtensiveWidgetProvider.java
+++ b/app/src/main/java/cz/martykan/forecastie/widgets/ExtensiveWidgetProvider.java
@@ -23,6 +23,8 @@ public class ExtensiveWidgetProvider extends AbstractWidgetProvider {
             RemoteViews remoteViews = new RemoteViews(context.getPackageName(),
                     R.layout.extensive_widget);
 
+            setTheme(context, remoteViews);
+
             Intent intent = new Intent(context, AlarmReceiver.class);
             PendingIntent pendingIntent = PendingIntent.getBroadcast(context,
                     0, intent, PendingIntent.FLAG_UPDATE_CURRENT);

--- a/app/src/main/java/cz/martykan/forecastie/widgets/ExtensiveWidgetProvider.java
+++ b/app/src/main/java/cz/martykan/forecastie/widgets/ExtensiveWidgetProvider.java
@@ -63,6 +63,7 @@ public class ExtensiveWidgetProvider extends AbstractWidgetProvider {
 
             appWidgetManager.updateAppWidget(widgetId, remoteViews);
         }
+        scheduleNextUpdate(context);
     }
 
 }

--- a/app/src/main/java/cz/martykan/forecastie/widgets/SimpleWidgetProvider.java
+++ b/app/src/main/java/cz/martykan/forecastie/widgets/SimpleWidgetProvider.java
@@ -35,6 +35,8 @@ public class SimpleWidgetProvider extends AbstractWidgetProvider {
             RemoteViews remoteViews = new RemoteViews(context.getPackageName(),
                     R.layout.simple_widget);
 
+            setTheme(context, remoteViews);
+
             Intent intent = new Intent(context, AlarmReceiver.class);
             PendingIntent pendingIntent = PendingIntent.getBroadcast(context,
                     0, intent, PendingIntent.FLAG_UPDATE_CURRENT);

--- a/app/src/main/java/cz/martykan/forecastie/widgets/SimpleWidgetProvider.java
+++ b/app/src/main/java/cz/martykan/forecastie/widgets/SimpleWidgetProvider.java
@@ -22,13 +22,6 @@ import cz.martykan.forecastie.R;
 import cz.martykan.forecastie.models.Weather;
 
 public class SimpleWidgetProvider extends AbstractWidgetProvider {
-
-    private static final String TAG = "SimpleWidgetProvider";
-
-    private static final String ACTION_UPDATE_TIME = "cz.martykan.forecastie.UPDATE_TIME";
-
-    private static final long DURATION_MINUTE = TimeUnit.SECONDS.toMillis(30);
-
     @Override
     public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
         for (int widgetId : appWidgetIds) {
@@ -69,51 +62,4 @@ public class SimpleWidgetProvider extends AbstractWidgetProvider {
         }
         scheduleNextUpdate(context);
     }
-
-    @Override
-    public void onReceive(Context context, Intent intent) {
-        if (ACTION_UPDATE_TIME.equals(intent.getAction())) {
-            AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
-            ComponentName provider = new ComponentName(context.getPackageName(), getClass().getName());
-            int ids[] = appWidgetManager.getAppWidgetIds(provider);
-            onUpdate(context, appWidgetManager, ids);
-        } else {
-            super.onReceive(context, intent);
-        }
-    }
-
-    @Override
-    public void onDisabled(Context context) {
-        super.onDisabled(context);
-
-        Log.d(TAG, "Disable simple widget updates");
-        cancelUpdate(context);
-    }
-
-    private static void scheduleNextUpdate(Context context) {
-        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-        long now = new Date().getTime();
-        long nextUpdate = now + DURATION_MINUTE - now % DURATION_MINUTE;
-        if (BuildConfig.DEBUG) {
-            Log.v(TAG, "Next widget update: " +
-                    android.text.format.DateFormat.getTimeFormat(context).format(new Date(nextUpdate)));
-        }
-        if (Build.VERSION.SDK_INT >= 19) {
-            alarmManager.setExact(AlarmManager.RTC, nextUpdate, getTimeIntent(context));
-        } else {
-            alarmManager.set(AlarmManager.RTC, nextUpdate, getTimeIntent(context));
-        }
-    }
-
-    private static void cancelUpdate(Context context) {
-        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-        alarmManager.cancel(getTimeIntent(context));
-    }
-
-    private static PendingIntent getTimeIntent(Context context) {
-        Intent intent = new Intent(context, SimpleWidgetProvider.class);
-        intent.setAction(ACTION_UPDATE_TIME);
-        return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
-    }
-
 }

--- a/app/src/main/java/cz/martykan/forecastie/widgets/SimpleWidgetProvider.java
+++ b/app/src/main/java/cz/martykan/forecastie/widgets/SimpleWidgetProvider.java
@@ -1,22 +1,14 @@
 package cz.martykan.forecastie.widgets;
 
-import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.preference.PreferenceManager;
-import android.util.Log;
 import android.widget.RemoteViews;
 
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
-
 import cz.martykan.forecastie.AlarmReceiver;
-import cz.martykan.forecastie.BuildConfig;
 import cz.martykan.forecastie.activities.MainActivity;
 import cz.martykan.forecastie.R;
 import cz.martykan.forecastie.models.Weather;

--- a/app/src/main/java/cz/martykan/forecastie/widgets/TimeWidgetProvider.java
+++ b/app/src/main/java/cz/martykan/forecastie/widgets/TimeWidgetProvider.java
@@ -37,6 +37,8 @@ public class TimeWidgetProvider extends AbstractWidgetProvider {
             RemoteViews remoteViews = new RemoteViews(context.getPackageName(),
                     R.layout.time_widget);
 
+            setTheme(context, remoteViews);
+
             Intent intent = new Intent(context, AlarmReceiver.class);
             PendingIntent pendingIntent = PendingIntent.getBroadcast(context,
                     0, intent, PendingIntent.FLAG_UPDATE_CURRENT);

--- a/app/src/main/java/cz/martykan/forecastie/widgets/TimeWidgetProvider.java
+++ b/app/src/main/java/cz/martykan/forecastie/widgets/TimeWidgetProvider.java
@@ -1,24 +1,18 @@
 package cz.martykan.forecastie.widgets;
 
-import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.preference.PreferenceManager;
-import android.util.Log;
 import android.widget.RemoteViews;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.concurrent.TimeUnit;
 
 import cz.martykan.forecastie.AlarmReceiver;
-import cz.martykan.forecastie.BuildConfig;
 import cz.martykan.forecastie.activities.MainActivity;
 import cz.martykan.forecastie.R;
 import cz.martykan.forecastie.models.Weather;

--- a/app/src/main/java/cz/martykan/forecastie/widgets/TimeWidgetProvider.java
+++ b/app/src/main/java/cz/martykan/forecastie/widgets/TimeWidgetProvider.java
@@ -24,13 +24,6 @@ import cz.martykan.forecastie.R;
 import cz.martykan.forecastie.models.Weather;
 
 public class TimeWidgetProvider extends AbstractWidgetProvider {
-
-    private static final String TAG = "TimeWidgetProvider";
-
-    private static final String ACTION_UPDATE_TIME = "cz.martykan.forecastie.UPDATE_TIME";
-
-    private static final long DURATION_MINUTE = TimeUnit.SECONDS.toMillis(30);
-
     @Override
     public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
         for (int widgetId : appWidgetIds) {
@@ -88,51 +81,4 @@ public class TimeWidgetProvider extends AbstractWidgetProvider {
         }
         scheduleNextUpdate(context);
     }
-
-    @Override
-    public void onReceive(Context context, Intent intent) {
-        if (ACTION_UPDATE_TIME.equals(intent.getAction())) {
-            AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
-            ComponentName provider = new ComponentName(context.getPackageName(), getClass().getName());
-            int ids[] = appWidgetManager.getAppWidgetIds(provider);
-            onUpdate(context, appWidgetManager, ids);
-        } else {
-            super.onReceive(context, intent);
-        }
-    }
-
-    @Override
-    public void onDisabled(Context context) {
-        super.onDisabled(context);
-
-        Log.d(TAG, "Disable time widget updates");
-        cancelUpdate(context);
-    }
-
-    private static void scheduleNextUpdate(Context context) {
-        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-        long now = new Date().getTime();
-        long nextUpdate = now + DURATION_MINUTE - now % DURATION_MINUTE;
-        if (BuildConfig.DEBUG) {
-            Log.v(TAG, "Next widget update: " +
-                    android.text.format.DateFormat.getTimeFormat(context).format(new Date(nextUpdate)));
-        }
-        if (Build.VERSION.SDK_INT >= 19) {
-            alarmManager.setExact(AlarmManager.RTC, nextUpdate, getTimeIntent(context));
-        } else {
-            alarmManager.set(AlarmManager.RTC, nextUpdate, getTimeIntent(context));
-        }
-    }
-
-    private static void cancelUpdate(Context context) {
-        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-        alarmManager.cancel(getTimeIntent(context));
-    }
-
-    private static PendingIntent getTimeIntent(Context context) {
-        Intent intent = new Intent(context, TimeWidgetProvider.class);
-        intent.setAction(ACTION_UPDATE_TIME);
-        return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
-    }
-
 }

--- a/app/src/main/res/drawable/widget_card_black.xml
+++ b/app/src/main/res/drawable/widget_card_black.xml
@@ -4,7 +4,7 @@
     <item>
         <shape>
             <padding android:bottom="4dp" android:top="4dp" android:left="4dp" android:right="4dp"/>
-            <solid android:color="@color/colorPrimary" />
+            <solid android:color="@color/blackTheme_colorBackground" />
             <corners android:radius="4dp" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/widget_card_classic.xml
+++ b/app/src/main/res/drawable/widget_card_classic.xml
@@ -4,7 +4,7 @@
     <item>
         <shape>
             <padding android:bottom="4dp" android:top="4dp" android:left="4dp" android:right="4dp"/>
-            <solid android:color="@color/colorPrimary" />
+            <solid android:color="@color/classic_colorPrimary" />
             <corners android:radius="4dp" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/widget_card_dark.xml
+++ b/app/src/main/res/drawable/widget_card_dark.xml
@@ -4,7 +4,7 @@
     <item>
         <shape>
             <padding android:bottom="4dp" android:top="4dp" android:left="4dp" android:right="4dp"/>
-            <solid android:color="@color/colorPrimary" />
+            <solid android:color="@color/darkTheme_colorBackground" />
             <corners android:radius="4dp" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/widget_card_transparent.xml
+++ b/app/src/main/res/drawable/widget_card_transparent.xml
@@ -4,7 +4,7 @@
     <item>
         <shape>
             <padding android:bottom="4dp" android:top="4dp" android:left="4dp" android:right="4dp"/>
-            <solid android:color="@color/colorPrimary" />
+            <solid android:color="@android:color/transparent" />
             <corners android:radius="4dp" />
         </shape>
     </item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="setting_showTempAsInteger">Show temperature only as an integer</string>
     <string name="setting_pressureUnits">Pressure units</string>
     <string name="setting_theme">Theme</string>
+    <string name="setting_transparent_widget">Make widget transparent</string>
     <string name="setting_auto_detect_location">Detect Location</string>
     <string name="setting_differentiateDaysByTint">Differentiate Days with Color</string>
     <string name="setting_refreshInterval">Background refresh interval</string>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -57,6 +57,10 @@
             android:key="theme"
             android:title="@string/setting_theme" />
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="transparentWidget"
+            android:title="@string/setting_transparent_widget" />
         <ListPreference
             android:defaultValue="arrow"
             android:entries="@array/windDirectionFormats"


### PR DESCRIPTION
I've made the widget conform to the theme that's configured for the app. I've done this by creating widget backgrounds that match the existing themes using the same predefined colors. The mapping is as follows:
* For the Fresh and Classic themes, the widget uses the primary color of the theme (blue and grey, respectively)
* For the dark and black themes, the widget uses the background color, which is the color shown in the lower part of the app.

I've created a separate configuration that allows you to make the widget transparent, in which case the selected theme no longer has any effect on the widget. Given the white font, this works best with dark backgrounds but since it's optional this doesn't seem like a problem.

<img src="https://user-images.githubusercontent.com/5629937/39927483-a4baa61a-5532-11e8-832a-61bb90f4d899.png" width=30%> <img src="https://user-images.githubusercontent.com/5629937/39927063-6be0453a-5531-11e8-8944-14bc69f23e78.png" width=30%> <img src="https://user-images.githubusercontent.com/5629937/39927061-6bc5316e-5531-11e8-92df-973d865b138d.png" width=30%>

I also took the opportunity to move a lot of duplicated code from the separate widget providers to the abstract parent class. The only side-effect is that the extensive widget provider now also uses those methods. This seemed like a good thing, but I'm not sure if this was kept out of that class on purpose. 

This should cover most of what was mentioned in #133. The text in the setting does use the strings XML file, but I didn't add any translations. 