### PR TITLE
Re-enable horizontal resize for time widget

### DIFF
--- a/app/src/main/res/xml/time_widget.xml
+++ b/app/src/main/res/xml/time_widget.xml
@@ -4,7 +4,7 @@
     android:minHeight="50dp"
     android:updatePeriodMillis="1800000"
     android:initialLayout="@layout/time_widget"
-    android:resizeMode="vertical"
+    android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen|keyguard"
     android:previewImage="@drawable/widget_preview_time">
 </appwidget-provider>


### PR DESCRIPTION
This was disabled in #233 though it's not clear why. For the time widget, it takes up 4x1 space by default for me. My phone allows 5 columns though. So if the widget isn't horizontally resizable, I always have a 1-column space next to it. I'd prefer to have it full-width, so 5x1. This is why I think the horizontal resize should be re-enabled. 

Having done this, the widget still defaults to 4x1 for me (though from reading the other issues this seems resolution-dependent). The point of this PR is that this doesn't change anything about the default size of the widget. It just makes it possible to resize it horizontally to more than 4 columns (but not less than 4 columns, due to the minimum width requirements).