### PR TITLE
Replace the "About" WebView with a FragmentDialog

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
@@ -7,8 +7,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
-import android.content.res.TypedArray;
-import android.graphics.Color;
 import android.graphics.Typeface;
 import android.location.Location;
 import android.location.LocationListener;
@@ -35,7 +33,6 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.webkit.WebView;
 import android.widget.EditText;
 import android.widget.TextView;
 
@@ -58,6 +55,7 @@ import cz.martykan.forecastie.Constants;
 import cz.martykan.forecastie.R;
 import cz.martykan.forecastie.adapters.ViewPagerAdapter;
 import cz.martykan.forecastie.adapters.WeatherRecyclerAdapter;
+import cz.martykan.forecastie.fragments.AboutDialogFragment;
 import cz.martykan.forecastie.fragments.AmbiguousLocationDialogFragment;
 import cz.martykan.forecastie.fragments.RecyclerViewFragment;
 import cz.martykan.forecastie.models.Weather;
@@ -336,35 +334,7 @@ public class MainActivity extends AppCompatActivity implements LocationListener 
     }
 
     private void aboutDialog() {
-        AlertDialog.Builder alert = new AlertDialog.Builder(this);
-        alert.setTitle("Forecastie");
-        final WebView webView = new WebView(this);
-        String about = "<p>1.9.1</p>" +
-                "<p>A lightweight, Free Software weather app, released under the GPL3 licence.</p>" +
-                "<p>Developed by <a href='mailto:t.martykan@gmail.com'>Tomas Martykan</a> and others</p>" +
-                "<p>Code is available at <a href='https://github.com/martykan/forecastie'>Forecastie</a>" +
-                "<p>Data provided by <a href='https://openweathermap.org/'>OpenWeatherMap</a>, under the <a href='http://creativecommons.org/licenses/by-sa/2.0/'>Creative Commons license</a>" +
-                "<p>Icons are <a href='https://erikflowers.github.io/weather-icons/'>Weather Icons</a>, by <a href='http://www.twitter.com/artill'>Lukas Bischoff</a> and <a href='http://www.twitter.com/Erik_UX'>Erik Flowers</a>, under the <a href='http://scripts.sil.org/OFL'>SIL OFL 1.1</a> licence.";
-        TypedArray ta = obtainStyledAttributes(new int[]{android.R.attr.textColorPrimary, R.attr.colorAccent});
-        String textColor = String.format("#%06X", (0xFFFFFF & ta.getColor(0, Color.BLACK)));
-        String accentColor = String.format("#%06X", (0xFFFFFF & ta.getColor(1, Color.BLUE)));
-        ta.recycle();
-        about = "<style media=\"screen\" type=\"text/css\">" +
-                "body {\n" +
-                "    color:" + textColor + ";\n" +
-                "}\n" +
-                "a:link {color:" + accentColor + "}\n" +
-                "</style>" +
-                about;
-        webView.setBackgroundColor(Color.TRANSPARENT);
-        webView.loadData(about, "text/html", "UTF-8");
-        alert.setView(webView, 32, 0, 32, 0);
-        alert.setPositiveButton(R.string.dialog_ok, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int whichButton) {
-
-            }
-        });
-        alert.show();
+        new AboutDialogFragment().show(getSupportFragmentManager(), null);
     }
 
     public static String getRainString(JSONObject rainObj) {

--- a/app/src/main/java/cz/martykan/forecastie/fragments/AboutDialogFragment.java
+++ b/app/src/main/java/cz/martykan/forecastie/fragments/AboutDialogFragment.java
@@ -1,0 +1,27 @@
+package cz.martykan.forecastie.fragments;
+
+import android.app.Dialog;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
+import android.text.method.LinkMovementMethod;
+import android.widget.TextView;
+
+import cz.martykan.forecastie.R;
+
+public class AboutDialogFragment extends DialogFragment {
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        AlertDialog alertDialog = new AlertDialog.Builder(getActivity())
+                .setTitle(getText(R.string.app_name))
+                .setMessage(getText(R.string.about_dialog))
+                .setPositiveButton(R.string.dialog_ok, null)
+                .create();
+        alertDialog.show();
+        ((TextView)alertDialog.findViewById(android.R.id.message)).setMovementMethod(LinkMovementMethod.getInstance());
+        return alertDialog;
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,4 +140,5 @@
     <string name="rain">Rain</string>
     <string name="temperature">Temperature</string>
     <string name="action_graphs">Graphs</string>
+    <string name="about_dialog">1.9.1\n\nA lightweight, Free Software weather app, released under the GPL3 licence.\n\nDeveloped by <a href='mailto:t.martykan@gmail.com'>Tomas Martykan</a> and others\n\nCode is available at <a href='https://github.com/martykan/forecastie'>Forecastie</a>\n\nData provided by <a href='https://openweathermap.org/'>OpenWeatherMap</a>, under the <a href='http://creativecommons.org/licenses/by-sa/2.0/'>Creative Commons license</a>\n\nIcons are <a href='https://erikflowers.github.io/weather-icons/'>Weather Icons</a>, by <a href='http://www.twitter.com/artill'>Lukas Bischoff</a> and <a href='http://www.twitter.com/Erik_UX'>Erik Flowers</a>, under the <a href='http://scripts.sil.org/OFL'>SIL OFL 1.1</a> licence.</string>
 </resources>


### PR DESCRIPTION
This code relates to the #203 issue. WebView has been replaced with a regular TextView inside FragmentDialog. Hardcoded dialog body is now in strings.xml and can be translated.

This type of dialog is kept alive in case of screen orientation change (discussed in #274). Links are functional and open in an internet browser.

