### PR TITLE
Use the sp unit for text size

### DIFF
--- a/app/src/main/res/layout/activity_graph.xml
+++ b/app/src/main/res/layout/activity_graph.xml
@@ -1,144 +1,141 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:chart="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/graph_scrollView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="?attr/colorPrimary"
     tools:context="cz.martykan.forecastie.activities.GraphActivity">
 
-    <ScrollView
-        android:id="@+id/graph_scrollView"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="?attr/colorPrimary">
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
-        <LinearLayout
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/graph_toolbar"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:layout_height="?attr/actionBarSize"
+            android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+            app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
 
-            <android.support.v7.widget.Toolbar
-                android:id="@+id/graph_toolbar"
-                android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
-                android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-                app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+        <android.support.v7.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_margin="16dp">
 
-            <android.support.v7.widget.CardView
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_margin="16dp">
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:orientation="vertical"
-                    android:layout_margin="16dp">
-
-                    <TextView
-                        android:id="@+id/graphTemperatureTextView"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="12dp"
-                        android:text="@string/temperature"
-                        android:textAlignment="center"
-                        android:textColor="@color/text_dark"
-                        android:textSize="18dp"/>
-
-                    <com.db.chart.view.LineChartView
-                        android:id="@+id/graph_temperature"
-                        android:layout_width="match_parent"
-                        android:layout_height="200dp"
-                        chart:chart_axisBorderSpacing="8dp" />
-                </LinearLayout>
-            </android.support.v7.widget.CardView>
-
-            <android.support.v7.widget.CardView
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_margin="16dp">
+                android:layout_margin="16dp"
+                android:orientation="vertical">
 
-                <LinearLayout
+                <TextView
+                    android:id="@+id/graphTemperatureTextView"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:orientation="vertical"
-                    android:layout_margin="16dp">
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="12dp"
+                    android:text="@string/temperature"
+                    android:textAlignment="center"
+                    android:textColor="@color/text_dark"
+                    android:textSize="18sp" />
 
-                    <TextView
-                        android:id="@+id/graphRainTextView"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="12dp"
-                        android:text="@string/rain"
-                        android:textAlignment="center"
-                        android:textColor="@color/text_dark" android:textSize="18dp"/>
+                <com.db.chart.view.LineChartView
+                    android:id="@+id/graph_temperature"
+                    android:layout_width="match_parent"
+                    android:layout_height="200dp"
+                    chart:chart_axisBorderSpacing="8dp" />
+            </LinearLayout>
+        </android.support.v7.widget.CardView>
 
-                    <com.db.chart.view.LineChartView
-                        android:id="@+id/graph_rain"
-                        android:layout_width="match_parent"
-                        android:layout_height="200dp"
-                        chart:chart_axisBorderSpacing="8dp" />
-                </LinearLayout>
-            </android.support.v7.widget.CardView>
+        <android.support.v7.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_margin="16dp">
 
-            <android.support.v7.widget.CardView
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_margin="16dp">
+                android:layout_margin="16dp"
+                android:orientation="vertical">
 
-                <LinearLayout
+                <TextView
+                    android:id="@+id/graphRainTextView"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:orientation="vertical"
-                    android:layout_margin="16dp">
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="12dp"
+                    android:text="@string/rain"
+                    android:textAlignment="center"
+                    android:textColor="@color/text_dark"
+                    android:textSize="18sp" />
 
-                    <TextView
-                        android:id="@+id/graphPressureTextView"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="12dp"
-                        android:text="@string/pressure"
-                        android:textAlignment="center"
-                        android:textColor="@color/text_dark" android:textSize="18dp"/>
+                <com.db.chart.view.LineChartView
+                    android:id="@+id/graph_rain"
+                    android:layout_width="match_parent"
+                    android:layout_height="200dp"
+                    chart:chart_axisBorderSpacing="8dp" />
+            </LinearLayout>
+        </android.support.v7.widget.CardView>
 
-                    <com.db.chart.view.LineChartView
-                        android:id="@+id/graph_pressure"
-                        android:layout_width="match_parent"
-                        android:layout_height="200dp"
-                        chart:chart_axisBorderSpacing="8dp" />
-                </LinearLayout>
-            </android.support.v7.widget.CardView>
+        <android.support.v7.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_margin="16dp">
 
-            <android.support.v7.widget.CardView
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_margin="16dp">
+                android:layout_margin="16dp"
+                android:orientation="vertical">
 
-                <LinearLayout
+                <TextView
+                    android:id="@+id/graphPressureTextView"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:orientation="vertical"
-                    android:layout_margin="16dp">
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="12dp"
+                    android:text="@string/pressure"
+                    android:textAlignment="center"
+                    android:textColor="@color/text_dark"
+                    android:textSize="18sp" />
 
-                    <TextView
-                        android:id="@+id/graphWindSpeedTextView"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="12dp"
-                        android:text="@string/wind_speed"
-                        android:textAlignment="center"
-                        android:textColor="@android:color/black"
-                        android:textSize="18dp"/>
+                <com.db.chart.view.LineChartView
+                    android:id="@+id/graph_pressure"
+                    android:layout_width="match_parent"
+                    android:layout_height="200dp"
+                    chart:chart_axisBorderSpacing="8dp" />
+            </LinearLayout>
+        </android.support.v7.widget.CardView>
 
-                    <com.db.chart.view.LineChartView
-                        android:id="@+id/graph_windspeed"
-                        android:layout_width="match_parent"
-                        android:layout_height="200dp"
-                        chart:chart_axisBorderSpacing="8dp" />
-                </LinearLayout>
-            </android.support.v7.widget.CardView>
+        <android.support.v7.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_margin="16dp">
 
-        </LinearLayout>
-    </ScrollView>
-</RelativeLayout>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_margin="16dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/graphWindSpeedTextView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="12dp"
+                    android:text="@string/wind_speed"
+                    android:textAlignment="center"
+                    android:textColor="@android:color/black"
+                    android:textSize="18sp" />
+
+                <com.db.chart.view.LineChartView
+                    android:id="@+id/graph_windspeed"
+                    android:layout_width="match_parent"
+                    android:layout_height="200dp"
+                    chart:chart_axisBorderSpacing="8dp" />
+            </LinearLayout>
+        </android.support.v7.widget.CardView>
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/activity_scrolling.xml
+++ b/app/src/main/res/layout/activity_scrolling.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<android.support.v4.widget.SwipeRefreshLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.v4.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/swipeRefreshLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -52,66 +51,66 @@
                             android:id="@+id/todayTemperature"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="0 °C"
+                            tools:text="0 °C"
                             android:textColor="@color/text_light"
-                            android:textSize="36dp"/>
+                            android:textSize="36sp"/>
 
                         <TextView
                             android:id="@+id/todayDescription"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="No data"
+                            tools:text="No data"
                             android:textColor="@color/text_light"
-                            android:textSize="16dp"/>
+                            android:textSize="16sp"/>
 
                         <TextView
                             android:id="@+id/todayWind"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="8dp"
-                            android:text="Wind: 0 m/s"
+                            tools:text="Wind: 0 m/s"
                             android:textColor="@color/text_light"
-                            android:textSize="16dp"/>
+                            android:textSize="16sp"/>
 
                         <TextView
                             android:id="@+id/todayPressure"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Pressure: 0 hpa"
+                            tools:text="Pressure: 0 hpa"
                             android:textColor="@color/text_light"
-                            android:textSize="16dp"/>
+                            android:textSize="16sp"/>
 
                         <TextView
                             android:id="@+id/todayHumidity"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Humidity: 0 %"
+                            tools:text="Humidity: 0 %"
                             android:textColor="@color/text_light"
-                            android:textSize="16dp"/>
+                            android:textSize="16sp"/>
 
                         <TextView
                             android:id="@+id/todaySunrise"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Sunrise: 00:00"
+                            tools:text="Sunrise: 00:00"
                             android:textColor="@color/text_light"
-                            android:textSize="16dp"/>
+                            android:textSize="16sp"/>
 
                         <TextView
                             android:id="@+id/todaySunset"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Sunset: 00:00"
+                            tools:text="Sunset: 00:00"
                             android:textColor="@color/text_light"
-                            android:textSize="16dp"/>
+                            android:textSize="16sp"/>
 
                         <TextView
                             android:id="@+id/todayUvIndex"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Uv Index: Loading..."
+                            tools:text="Uv Index: Loading..."
                             android:textColor="@color/text_light"
-                            android:textSize="16dp"/>
+                            android:textSize="16sp"/>
                     </LinearLayout>
 
                     <LinearLayout
@@ -129,7 +128,7 @@
                             android:paddingRight="42dp"
                             android:text=""
                             android:textAlignment="viewEnd"
-                            android:textSize="72dp"/>
+                            android:textSize="72sp"/>
 
                         <TextView
                             android:id="@+id/lastUpdate"
@@ -139,7 +138,7 @@
                             android:gravity="bottom|end"
                             android:paddingRight="16dp"
                             android:textAlignment="viewEnd"
-                            android:textSize="16dp"/>
+                            android:textSize="16sp"/>
                     </LinearLayout>
 
 

--- a/app/src/main/res/layout/list_row.xml
+++ b/app/src/main/res/layout/list_row.xml
@@ -2,13 +2,14 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
     android:paddingBottom="16dp"
     android:orientation="vertical">
 
     <View
         android:id="@+id/lineView"
         android:layout_width="match_parent"
-        android:layout_height="2px"
+        android:layout_height="1dp"
         android:background="?android:attr/listDivider" />
 
     <RelativeLayout
@@ -26,39 +27,39 @@
                 android:id="@+id/itemDate"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="16:00"
+                tools:text="16:00"
                 android:textColor="?android:textColorPrimary"
-                android:textSize="16dp"
+                android:textSize="16sp"
                 android:textStyle="bold" />
 
             <TextView
                 android:id="@+id/itemDescription"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="No data"
-                android:textSize="16dp" />
+                tools:text="No data"
+                android:textSize="16sp" />
 
             <TextView
                 android:id="@+id/itemWind"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:text="Wind: 0 m/s"
-                android:textSize="16dp" />
+                tools:text="Wind: 0 m/s"
+                android:textSize="16sp" />
 
             <TextView
                 android:id="@+id/itemPressure"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Pressure: 0 hpa"
-                android:textSize="16dp" />
+                tools:text="Pressure: 0 hpa"
+                android:textSize="16sp" />
 
             <TextView
                 android:id="@+id/itemHumidity"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Humidity: 0 %"
-                android:textSize="16dp" />
+                tools:text="Humidity: 0 %"
+                android:textSize="16sp" />
         </LinearLayout>
 
         <TextView
@@ -71,15 +72,15 @@
             android:layout_marginRight="16dp"
             android:layout_marginTop="16dp"
             android:layout_weight="1"
-            android:text="o"
-            android:textSize="48dp" />
+            tools:text="o"
+            android:textSize="48sp" />
 
         <TextView
             android:id="@+id/itemTemperature"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="0 °C"
-            android:textSize="22dp"
+            tools:text="0 °C"
+            android:textSize="22sp"
             android:layout_marginTop="8dp"
             android:layout_below="@+id/itemIcon"
             android:layout_alignRight="@+id/itemIcon"


### PR DESCRIPTION
Hi,
This commit changes text size units from dp to sp. That way, the application respects the android system-wide text size setting.

Since I was already there, I placed the hard-coded strings into "tools:text" so they are not unnecessarily included in the apk file. Also, there was one redundant RelativeLayout and one dimension in px - I converted it to dp.