### PR TITLE
Issue 325 -  Make AlarmReceiver work with both city names and IDs

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/AlarmReceiver.java
+++ b/app/src/main/java/cz/martykan/forecastie/AlarmReceiver.java
@@ -104,7 +104,7 @@ public class AlarmReceiver extends BroadcastReceiver {
                 String language = Locale.getDefault().getLanguage();
                 if(language.equals("cs")) { language = "cz"; }
                 String apiKey = sp.getString("apiKey", context.getResources().getString(R.string.apiKey));
-                URL url = new URL("https://api.openweathermap.org/data/2.5/weather?q=" + URLEncoder.encode(sp.getString("city", Constants.DEFAULT_CITY), "UTF-8") + "&lang="+ language +"&appid=" + apiKey);
+                URL url = new URL("https://api.openweathermap.org/data/2.5/weather?id=" + URLEncoder.encode(sp.getString("cityId", Constants.DEFAULT_CITY_ID), "UTF-8") + "&lang="+ language +"&appid=" + apiKey);
                 HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
                 BufferedReader r = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
 
@@ -148,7 +148,7 @@ public class AlarmReceiver extends BroadcastReceiver {
                 String language = Locale.getDefault().getLanguage();
                 if(language.equals("cs")) { language = "cz"; }
                 String apiKey = sp.getString("apiKey", context.getResources().getString(R.string.apiKey));
-                URL url = new URL("https://api.openweathermap.org/data/2.5/forecast?q=" + URLEncoder.encode(sp.getString("city", Constants.DEFAULT_CITY), "UTF-8") + "&lang="+ language +"&mode=json&appid=" + apiKey);
+                URL url = new URL("https://api.openweathermap.org/data/2.5/forecast?id=" + URLEncoder.encode(sp.getString("cityId", Constants.DEFAULT_CITY_ID), "UTF-8") + "&lang="+ language +"&mode=json&appid=" + apiKey);
                 HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
                 BufferedReader r = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
 
@@ -298,6 +298,7 @@ public class AlarmReceiver extends BroadcastReceiver {
                     Log.d(TAG, "JSON Result: " + result);
                     try {
                         JSONObject reader = new JSONObject(result);
+                        String cityId = reader.getString("cityId");
                         String city = reader.getString("name");
                         String country = "";
                         JSONObject countryObj = reader.optJSONObject("sys");
@@ -308,6 +309,7 @@ public class AlarmReceiver extends BroadcastReceiver {
                         String lastCity = PreferenceManager.getDefaultSharedPreferences(context).getString("city", "");
                         String currentCity = city + country;
                         SharedPreferences.Editor editor = sp.edit();
+                        editor.putString("cityId", cityId);
                         editor.putString("city", currentCity);
                         editor.putBoolean("cityChanged", !currentCity.equals(lastCity));
                         editor.commit();

--- a/app/src/main/java/cz/martykan/forecastie/AlarmReceiver.java
+++ b/app/src/main/java/cz/martykan/forecastie/AlarmReceiver.java
@@ -98,7 +98,6 @@ public class AlarmReceiver extends BroadcastReceiver {
 
         @Override
         protected Void doInBackground(String... params) {
-            String result = "";
             try {
                 SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
                 String language = Locale.getDefault().getLanguage();
@@ -106,20 +105,24 @@ public class AlarmReceiver extends BroadcastReceiver {
                 String apiKey = sp.getString("apiKey", context.getResources().getString(R.string.apiKey));
                 URL url = new URL("https://api.openweathermap.org/data/2.5/weather?id=" + URLEncoder.encode(sp.getString("cityId", Constants.DEFAULT_CITY_ID), "UTF-8") + "&lang="+ language +"&appid=" + apiKey);
                 HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
-                BufferedReader r = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
-
-                if(urlConnection.getResponseCode() == 200) {
-                    String line = null;
-                    while ((line = r.readLine()) != null) {
-                        result += line + "\n";
+                BufferedReader connectionBufferedReader = null;
+                try {
+                    connectionBufferedReader = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
+                    if (urlConnection.getResponseCode() == 200) {
+                        StringBuilder result = new StringBuilder();
+                        String line;
+                        while ((line = connectionBufferedReader.readLine()) != null) {
+                            result.append(line).append("\n");
+                        }
+                        SharedPreferences.Editor editor = sp.edit();
+                        editor.putString("lastToday", result.toString());
+                        editor.apply();
+                        MainActivity.saveLastUpdateTime(sp);
+                    } else {
+                        // Connection problem
                     }
-                    SharedPreferences.Editor editor = sp.edit();
-                    editor.putString("lastToday", result);
-                    editor.apply();
-                    MainActivity.saveLastUpdateTime(sp);
-                }
-                else {
-                    // Connection problem
+                } finally {
+                    if (connectionBufferedReader != null) connectionBufferedReader.close();
                 }
             } catch (IOException e) {
                 // No connection
@@ -142,7 +145,6 @@ public class AlarmReceiver extends BroadcastReceiver {
 
         @Override
         protected Void doInBackground(String... params) {
-            String result = "";
             try {
                 SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
                 String language = Locale.getDefault().getLanguage();
@@ -150,19 +152,23 @@ public class AlarmReceiver extends BroadcastReceiver {
                 String apiKey = sp.getString("apiKey", context.getResources().getString(R.string.apiKey));
                 URL url = new URL("https://api.openweathermap.org/data/2.5/forecast?id=" + URLEncoder.encode(sp.getString("cityId", Constants.DEFAULT_CITY_ID), "UTF-8") + "&lang="+ language +"&mode=json&appid=" + apiKey);
                 HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
-                BufferedReader r = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
-
-                if(urlConnection.getResponseCode() == 200) {
-                    String line = null;
-                    while ((line = r.readLine()) != null) {
-                        result += line + "\n";
+                BufferedReader connectionBufferedReader = null;
+                try {
+                    connectionBufferedReader = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
+                    if (urlConnection.getResponseCode() == 200) {
+                        StringBuilder result = new StringBuilder();
+                        String line;
+                        while ((line = connectionBufferedReader.readLine()) != null) {
+                            result.append(line).append("\n");
+                        }
+                        SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(context).edit();
+                        editor.putString("lastLongterm", result.toString());
+                        editor.apply();
+                    } else {
+                        // Connection problem
                     }
-                    SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(context).edit();
-                    editor.putString("lastLongterm", result);
-                    editor.apply();
-                }
-                else {
-                    // Connection problem
+                } finally {
+                    if (connectionBufferedReader != null) connectionBufferedReader.close();
                 }
             } catch (IOException e) {
                 // No connection
@@ -289,16 +295,17 @@ public class AlarmReceiver extends BroadcastReceiver {
                 HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
 
                 if (urlConnection.getResponseCode() == 200) {
-                    BufferedReader r = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
-                    String result = "";
-                    String line;
-                    while ((line = r.readLine()) != null) {
-                        result += line + "\n";
-                    }
-                    Log.d(TAG, "JSON Result: " + result);
+                    BufferedReader connectionBufferedReader = null;
                     try {
-                        JSONObject reader = new JSONObject(result);
-                        String cityId = reader.getString("cityId");
+                        connectionBufferedReader = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
+                        StringBuilder result = new StringBuilder();
+                        String line;
+                        while ((line = connectionBufferedReader.readLine()) != null) {
+                            result.append(line).append("\n");
+                        }
+                        Log.d(TAG, "JSON Result: " + result);
+                        JSONObject reader = new JSONObject(result.toString());
+                        String cityId = reader.getString("id");
                         String city = reader.getString("name");
                         String country = "";
                         JSONObject countryObj = reader.optJSONObject("sys");
@@ -316,6 +323,8 @@ public class AlarmReceiver extends BroadcastReceiver {
 
                     } catch (JSONException e){
                         Log.e(TAG, "An error occurred while reading the JSON object", e);
+                    } finally {
+                        if (connectionBufferedReader != null) connectionBufferedReader.close();
                     }
                 } else {
                     Log.e(TAG, "Error: Response code " + urlConnection.getResponseCode());

--- a/app/src/main/java/cz/martykan/forecastie/tasks/GenericRequestTask.java
+++ b/app/src/main/java/cz/martykan/forecastie/tasks/GenericRequestTask.java
@@ -78,11 +78,13 @@ public abstract class GenericRequestTask extends AsyncTask<String, String, TaskO
                     InputStreamReader inputStreamReader = new InputStreamReader(urlConnection.getInputStream());
                     BufferedReader r = new BufferedReader(inputStreamReader);
 
-                    int responseCode = urlConnection.getResponseCode();
-                    String line = null;
+                    StringBuilder stringBuilder = new StringBuilder();
+                    String line;
                     while ((line = r.readLine()) != null) {
-                        response += line + "\n";
+                        stringBuilder.append(line);
+                        stringBuilder.append("\n");
                     }
+                    response += stringBuilder.toString();
                     close(r);
                     urlConnection.disconnect();
                     // Background work finished successfully


### PR DESCRIPTION
Hi,
I was looking at #325. The issue is, the manual location selection saves the city ID, but AlarmReceiver works only with a city name. AlarmReceiver is responsible for updating data in the background.
That means the user may update their location manually, but as soon as the next update interval is met, AlarmReceiver downloads information for the previous city again, overwriting user location. The solution is to make AlarmReceiver work with city IDs.
Since I was there, I made another commit to close network resources once we are done reading from them and use StringBuilders where needed.