### PR TITLE
Don't use custom date format for widget

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/widgets/TimeWidgetProvider.java
+++ b/app/src/main/java/cz/martykan/forecastie/widgets/TimeWidgetProvider.java
@@ -10,7 +10,6 @@ import android.preference.PreferenceManager;
 import android.widget.RemoteViews;
 
 import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import cz.martykan.forecastie.AlarmReceiver;
@@ -50,20 +49,9 @@ public class TimeWidgetProvider extends AbstractWidgetProvider {
                 return;
             }
 
-            DateFormat timeFormat = android.text.format.DateFormat.getTimeFormat(context);
-            String defaultDateFormat = context.getResources().getStringArray(R.array.dateFormatsValues)[0];
-            String dateFormat = sp.getString("dateFormat", defaultDateFormat);
-            if ("custom".equals(dateFormat)) {
-                dateFormat = sp.getString("dateFormatCustom", defaultDateFormat);
-            }
-            dateFormat = dateFormat.substring(0, dateFormat.indexOf("-")-1);
-            String dateString;
-            try {
-                SimpleDateFormat resultFormat = new SimpleDateFormat(dateFormat);
-                dateString = resultFormat.format(new Date());
-            } catch (IllegalArgumentException e) {
-                dateString = context.getResources().getString(R.string.error_dateFormat);
-            }
+            DateFormat timeFormat = DateFormat.getTimeInstance(DateFormat.SHORT);
+            DateFormat dateFormat = DateFormat.getDateInstance(DateFormat.LONG);
+            String dateString = dateFormat.format(new Date());
 
             remoteViews.setTextViewText(R.id.time, timeFormat.format(new Date()));
             remoteViews.setTextViewText(R.id.date, dateString);


### PR DESCRIPTION
This fixes the crash reported in #361 and #287 by simply not using the custom date format for the widget anymore. The date is formatted now according to the device locale, as suggested here #272.