### PR TITLE
Detect Location menu not require permission after click deny

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
@@ -774,8 +774,7 @@ public class MainActivity extends BaseActivity implements LocationListener {
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
             if (ActivityCompat.shouldShowRequestPermissionRationale(this,
                     Manifest.permission.ACCESS_FINE_LOCATION)) {
-                // Explanation not needed, since user requests this themmself
-
+                showLocationSettingsDialog();
             } else {
                 ActivityCompat.requestPermissions(this,
                         new String[]{Manifest.permission.ACCESS_FINE_LOCATION},


### PR DESCRIPTION
Resolve for issue #358.

Runtime permission won't ask again when click **Deny**.
#[Screenshot](https://imgur.com/dDbC17L)

Then, should we let user to allow permission by themselves?.
#[Screenshot](https://imgur.com/JfT5iEd)