### PR TITLE
remove unused string - about_text

### DIFF
--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -163,10 +163,4 @@
     <string name="rain">강수량</string>
     <string name="temperature">기온</string>
     <string name="action_graphs">그래프</string>
-    <string name="about_text">GPL3 라이센스에 따라 출시 된 간단한 자유 소프트웨어 날씨 앱입니다.
-        \n\<a href='mailto:t.martykan@gmail.com'>Tomas Martykan</a> 등 다른인원들로부터 개발되었습니다.
-        \n\n코드는 <a href='https://github.com/martykan/forecastie'>Forecastie</a>에서 이용가능합니다.
-        \n\n<a href='http://creativecommons.org/licenses/by-sa/2.0/'>Creative Commons CC-BY-SA </a>라이센스에 따라 <a href='https://openweathermap.org/'>OpenWeatherMap</a>에서 제공한 데이터입니다.
-        \n\n<a href='http://scripts.sil.org/OFL'>아이콘은 SIL OFL 1.1</a> 라이센스에 따라 <a href='http://www.twitter.com/artill'>Lukas Bischoff</a> 및 <a href='http://www.twitter.com/Erik_UX'>Erik Flowers</a><a href='https://erikflowers.github.io/weather-icons/'>의 날씨 아이콘입니다.</a>
-    </string>
 </resources>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -154,6 +154,5 @@
     <string name="rain">Regn</string>
     <string name="temperature">Temperatur</string>
     <string name="action_graphs">Grafer</string>
-    <string name="about_text">En liten väder app, släppt under GPL3 licensen.\n\nUtvecklag av <a href='mailto:t.martykan@gmail.com'>Tomas Martykan</a> och andra\n\nKoden är tillgänglig på <a href='https://github.com/martykan/forecastie'>Forecastie</a>\n\nUppgifter tillhandahållna av <a href='https://openweathermap.org/'>OpenWeatherMap</a>, under <a href='http://creativecommons.org/licenses/by-sa/2.0/'>Creative Commons licensen</a>\n\nIkoner är <a href='https://erikflowers.github.io/weather-icons/'>Weather Icons</a>, av <a href='http://www.twitter.com/artill'>Lukas Bischoff</a> och <a href='http://www.twitter.com/Erik_UX'>Erik Flowers</a>, under <a href='http://scripts.sil.org/OFL'>SIL OFL 1.1</a> licensen.</string>
 
 </resources>


### PR DESCRIPTION
I found some unused string in strings.xml.
I think this was used for 'About'-attached picture- but now it's useless.
So I removed these.

![image](https://user-images.githubusercontent.com/33623107/68941087-31f26e00-07e8-11ea-9f7d-f89bb0d87aff.png)
