### PR TITLE
Translate weather description

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/activities/MainActivity.java
@@ -486,8 +486,7 @@ public class MainActivity extends BaseActivity implements LocationListener {
         double pressure = UnitConvertor.convertPressure((float) Double.parseDouble(todayWeather.getPressure()), sp);
 
         todayTemperature.setText(new DecimalFormat("0.#").format(temperature) + " " + sp.getString("unit", "°C"));
-        todayDescription.setText(todayWeather.getDescription().substring(0, 1).toUpperCase() +
-                todayWeather.getDescription().substring(1) + rainString);
+        todayDescription.setText(UnitConvertor.getDescription(todayWeather.getDescription(),this)+rainString);
         if (sp.getString("speedUnit", "m/s").equals("bft")) {
             todayWind.setText(getString(R.string.wind) + ": " +
                     UnitConvertor.getBeaufortName((int) wind, this) +

--- a/app/src/main/java/cz/martykan/forecastie/adapters/WeatherRecyclerAdapter.java
+++ b/app/src/main/java/cz/martykan/forecastie/adapters/WeatherRecyclerAdapter.java
@@ -109,8 +109,7 @@ public class WeatherRecyclerAdapter extends RecyclerView.Adapter<WeatherViewHold
         } else {
             customViewHolder.itemTemperature.setText(new DecimalFormat("#.#").format(temperature) + " " + sp.getString("unit", "°C"));
         }
-        customViewHolder.itemDescription.setText(weatherItem.getDescription().substring(0, 1).toUpperCase() +
-                weatherItem.getDescription().substring(1) + rainString);
+        customViewHolder.itemDescription.setText(UnitConvertor.getDescription(weatherItem.getDescription(),context)+rainString);
         Typeface weatherFont = Typeface.createFromAsset(context.getAssets(), "fonts/weather.ttf");
         customViewHolder.itemIcon.setTypeface(weatherFont);
         customViewHolder.itemIcon.setText(weatherItem.getIcon());

--- a/app/src/main/java/cz/martykan/forecastie/utils/UnitConvertor.java
+++ b/app/src/main/java/cz/martykan/forecastie/utils/UnitConvertor.java
@@ -161,4 +161,30 @@ public class UnitConvertor {
             return context.getString(R.string.beaufort_hurricane);
         }
     }
+
+    public static String getDescription(String status, Context context){
+        switch (status){
+            case "clear sky":
+                return context.getString(R.string.desc_clear_sky);
+            case "few clouds":
+                return context.getString(R.string.desc_few_clouds);
+            case "scattered clouds":
+                return context.getString(R.string.desc_scattered_clouds);
+            case "broken clouds":
+                return context.getString(R.string.desc_broken_clouds);
+            case "shower rain":
+                return context.getString(R.string.desc_shower_rain);
+            case "rain":
+                return context.getString(R.string.desc_rain);
+            case "thunderstorm":
+                return context.getString(R.string.desc_thunderstorm);
+            case "snow":
+                return context.getString(R.string.desc_snow);
+            case "mist":
+                return context.getString(R.string.desc_mist);
+            default:
+                return status.substring(0, 1).toUpperCase() +
+                status.substring(1);
+        }
+    }
 }

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -133,6 +133,16 @@
     <string name="beaufort_violent_storm">강력한 폭풍</string>
     <string name="beaufort_hurricane">태풍</string>
 
+    <string name="desc_clear_sky">맑음</string>
+    <string name="desc_few_clouds">구름 조금</string>
+    <string name="desc_scattered_clouds">흩어진 구름</string>
+    <string name="desc_broken_clouds">끊어진 구름</string>
+    <string name="desc_shower_rain">소나기</string>
+    <string name="desc_rain">비</string>
+    <string name="desc_thunderstorm">뇌우</string>
+    <string name="desc_snow">눈</string>
+    <string name="desc_mist">안개</string>
+
     <string name="uvi_no_info">정보가 없습니다</string>
     <string name="uvi_low">낮음</string>
     <string name="uvi_moderate">보통</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,6 +160,16 @@
     <string name="beaufort_violent_storm">Violent storm</string>
     <string name="beaufort_hurricane">Hurricane</string>
 
+    <string name="desc_clear_sky">clear sky</string>
+    <string name="desc_few_clouds">few clouds</string>
+    <string name="desc_scattered_clouds">scattered clouds</string>
+    <string name="desc_broken_clouds">broken clouds</string>
+    <string name="desc_shower_rain">shower rain</string>
+    <string name="desc_rain">rain</string>
+    <string name="desc_thunderstorm">thunderstorm</string>
+    <string name="desc_snow">snow</string>
+    <string name="desc_mist">mist</string>
+
     <string name="uvi_no_info">No Info</string>
     <string name="uvi_low">Low</string>
     <string name="uvi_moderate">Moderate</string>


### PR DESCRIPTION
In the displayed weather information, the weather description is still available only in English. Translated this description.
So I changed the way I added the string and set the description. It only translate the registered description.
You can use strings.xml to translate other languages. You can also extend the translated description by adding strings to strings.xml.

cf) I'm considering another way to get a description from strings.xml. Use the weather ID. For now I've implemented it to use the description.

![image](https://user-images.githubusercontent.com/33623107/69005138-c4b61880-0960-11ea-8126-3b41d8549b5b.png)
