### PR TITLE
Check for LocationManager.NETWORK_PROVIDER

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/activities/SettingsActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/activities/SettingsActivity.java
@@ -160,9 +160,11 @@ public class SettingsActivity extends PreferenceActivity
         // Workaround for CM privacy guard. Register for location updates in order for it to ask us for permission
         LocationManager locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
         try {
-            DummyLocationListener dummyLocationListener = new DummyLocationListener();
-            locationManager.requestLocationUpdates(LocationManager.NETWORK_PROVIDER, 0, 0, dummyLocationListener);
-            locationManager.removeUpdates(dummyLocationListener);
+            if (locationManager.getAllProviders().contains(LocationManager.NETWORK_PROVIDER)) {
+                DummyLocationListener dummyLocationListener = new DummyLocationListener();
+                locationManager.requestLocationUpdates(LocationManager.NETWORK_PROVIDER, 0, 0, dummyLocationListener);
+                locationManager.removeUpdates(dummyLocationListener);
+            }
         } catch (SecurityException e) {
             // This will most probably not happen, as we just got granted the permission
         }


### PR DESCRIPTION
 I add a check for LocationManager.NETWORK_PROVIDER to prevent IllegalArgumentException crashes, mentioned in #395. But I do not know what should we do if the 'network' property is not provided. A warning, or other approaches to request the LocationUpdates?