### PR TITLE
Bug fix. Was testing against the wrong file to see whether to proceed…

### DIFF
--- a/reorderAll.sh
+++ b/reorderAll.sh
@@ -6,8 +6,8 @@
 TEMPLATE='reorderTemplate'
 
 reorder(){
-    if [ -f "$1" ] ; then
-        echo "$1 already exists. Nothing done to it".
+    if [ -f "$1.out" ] ; then
+        echo "$1.out already exists. Nothing done to it".
     else
         while read LINE ; do
             OUTPUTLINE=""


### PR DESCRIPTION
The script creates a "script.xml.out" file in each of the translation file folders (called strings.xml.out). To create this file it appends on to the end of it so it's necessary to test if the file is already there first. If it does exist, nothing is attempted.