### PR TITLE
Improve (German) translation

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,15 +1,22 @@
 <resources>
     <string name="app_name">Forecastie</string>
-
+    <!-- Main activity titles -->
     <string name="action_search">Suche</string>
     <string name="action_refresh">Aktualisieren</string>
     <string name="action_settings">Einstellungen</string>
     <string name="action_about">Über die App</string>
+    <string name="search_title">Stadt suchen</string>
+    <string name="downloading_data">Lade Daten herunter...</string>
+    <string name="getting_location">Suche Standort...</string>
+    <string name="loading_data">Laden...</string>
 
+    <!-- Forecast cards -->
     <string name="today">Heute</string>
     <string name="tomorrow">Morgen</string>
     <string name="later">Später</string>
 
+    <!-- Main activity headings -->
+    <string name="wind">Wind</string>
     <string name="wind_speed">Windgeschwindigkeit</string>
     <string name="pressure">Luftdruck</string>
     <string name="humidity">Luftfeuchtigkeit</string>
@@ -17,40 +24,24 @@
     <string name="sunset">Sonnenuntergang</string>
     <string name="uvindex">UV-Index</string>
 
-    <string name="last_update">Zuletzt aktualisiert:\n%s</string>
-    <string name="last_update_widget">\nZuletzt aktualisiert: %s</string>
-
-    <string name="search_title">Stadt suchen</string>
-
-    <string name="downloading_data">Lade Daten herunter...</string>
-    <string name="getting_location">Suche Standort...</string>
-
-    <string name="loading_data">Laden...</string>
-
-    <string name="error_dateFormat">FEHLERHAFTES DATUMSFORMAT</string>
-
-    <string name="setting_dateFormat">Datumsformat</string>
-    <string name="setting_dateFormatCustom">Eigenes Datumsformat</string>
-    <string name="setting_dateFormatCustom_summary">Eigene Zeichenkette für SimpleDateFormat bereitstellen</string>
+    <!-- Settings/Units -->
+    <string name="settings_title_units">Einheiten</string>
     <string name="setting_lengthUnits">Längeneinheit</string>
     <string name="setting_speedUnits">Geschwindigkeitseinheit</string>
     <string name="setting_tempUnits">Temperatureinheit</string>
     <string name="setting_showTempAsInteger">Temperatur nur als Ganzzahl anzeigen</string>
     <string name="setting_pressureUnits">Maßeinheit Druck</string>
-    <string name="setting_theme">Design</string>
-    <string name="setting_transparent_widget">Widget transparent darstellen</string>
     <string name="setting_auto_detect_location">Standort feststellen</string>
     <string name="setting_differentiateDaysByTint">Farbliche Unterscheidung der Tage</string>
-    <string name="setting_refreshInterval">Aktualisierungsinterval im Hintergrund</string>
+
     <string name="setting_unit_mps">Meter pro Sekunde (m/s)</string>
     <string name="setting_unit_kph">Kilometer pro Stunde (km/h)</string>
     <string name="setting_unit_mph">Meilen pro Stunde (mph)</string>
     <string name="setting_unit_bft">Beaufortskala (bft)</string>
     <string name="setting_unit_kn">Knoten (kn)</string>
-    <string name="setting_wind_direction_format">Windrichtungsformat</string>
-    <string name="settings_none">Keins</string>
-    <string name="setting_apiKey">API-Schlüssel</string>
-    <string name="setting_apiKey_summary">Eigener API-Schlüssel für Anfragen an OpenWeatherMap</string>
+    <string name="setting_unit_Celsuis">Celsius</string>
+    <string name="setting_unit_Fahrenheit">Fahrenheit</string>
+    <string name="setting_unit_Kelvin">Kelvin</string>
 
     <string name="setting_unit_mm">Millimeter (mm)</string>
     <string name="setting_unit_in">Zoll (in)</string>
@@ -58,33 +49,75 @@
     <string name="setting_unit_hpa">hPa</string>
     <string name="setting_unit_kpa">kPa</string>
     <string name="setting_unit_mmhg">mmHg</string>
+    <string name="setting_unit_inhg">inHg</string>
 
     <string name="speed_unit_mps">m/s</string>
     <string name="speed_unit_kph">km/h</string>
     <string name="speed_unit_mph">mph</string>
     <string name="speed_unit_kn">kn</string>
 
-    <string name="wind_direction_format_none">Keine Angabe</string>
-    <string name="wind_direction_format_arrows">Pfeile</string>
-    <string name="wind_direction_format_abbreviations">Abkürzungen</string>
-
     <string name="pressure_unit_hpa">hPa</string>
     <string name="pressure_unit_kpa">kPa</string>
     <string name="pressure_unit_mmhg">mmHg</string>
 
+    <string name="uvi_no_info">Keine Daten</string>
+    <string name="uvi_low">Niedrig</string>
+    <string name="uvi_high">Hoch</string>
+    <string name="uvi_extreme">Extrem</string>
+    <string name="uvi_moderate">Mäßig</string>
+    <string name="uvi_very_high">Sehr hoch</string>
+
+    <!-- Settings/Appearance -->
+    <string name="settings_title_display">Anzeige</string>
+    <string name="setting_theme">Design</string>
+    <string name="setting_transparent_widget">Widget transparent darstellen</string>
+    <string name="setting_wind_direction_format">Windrichtungsformat</string>
     <string name="setting_theme_fresh">Frisch</string>
     <string name="setting_theme_classic">Klassisch</string>
     <string name="setting_theme_dark">Frisch Dunkel</string>
     <string name="setting_theme_classic_dark">Klassisch Dunkel</string>
+    <string name="setting_theme_black">Frisch Schwarz</string>
+    <string name="setting_theme_classic_black">Klassisch Schwarz</string>
 
+    <string name="wind_direction_format_none">Keine Angabe</string>
+    <string name="wind_direction_format_arrows">Pfeile</string>
+    <string name="wind_direction_format_abbreviations">Abkürzungen</string>
+    <string name="setting_displayDecimalZeroes">Zeige Null nach Komma</string>
+
+    <!-- Settings/Data -->
+    <string name="last_update">Zuletzt aktualisiert:\n%s</string>
+    <string name="last_update_widget">\nZuletzt aktualisiert: %s</string>
+    <string name="settings_title_data">Daten</string>
+    <string name="setting_refreshInterval">Aktualisierungsintervall im Hintergrund</string>
+    <string name="settings_none">Keins</string>
+    <string name="settings_15min">15 Minuten</string>
+    <string name="settings_30min">30 Minuten</string>
+    <string name="settings_1hour">1 Stunde</string>
+    <string name="settings_2hour">2 Stunden</string>
+    <string name="settings_6hour">6 Stunden</string>
+    <string name="settings_12hour">12 Stunden</string>
+    <string name="settings_24hour">24 Stunden</string>
+    <string name="setting_apiKey">API-Schlüssel</string>
+    <string name="setting_apiKey_summary">Eigener API-Schlüssel für Anfragen an OpenWeatherMap</string>
+
+    <!-- Settings/Date format -->
+    <string name="error_dateFormat">FEHLERHAFTES DATUMSFORMAT</string>
+    <string name="setting_dateFormat">Datumsformat</string>
+    <string name="setting_dateFormatCustom">Eigenes Datumsformat</string>
+    <string name="setting_dateFormatCustom_summary">Eigene Zeichenkette für SimpleDateFormat bereitstellen</string>
+    <string name="setting_simple_string_formatting_intro">Die folgenden Zeichen können für ein eigenes Datums- und Zeitformat genutzt werden</string>
+    <string name="setting_example_date_format">Mittwoch, 4 Jul 2001 12:08:32 PM, Mitteleuropäische Sommerzeit</string>
     <string name="dialog_ok">OK</string>
     <string name="dialog_cancel">Abbrechen</string>
 
+    <!-- Errors -->
     <string name="msg_err_parsing_json">Fehler beim Parsen von JSON</string>
     <string name="msg_connection_problem">Es gibt ein Problem mit der Internetverbindung.</string>
     <string name="msg_connection_not_available">Keine Verbindung</string>
     <string name="msg_city_not_found">Stadt konnte nicht gefunden werden.</string>
+    <string name="msg_too_many_requests">Zu viele Anfragen. Bitte erneut versuchen.</string>
 
+    <!-- Wind direction -->
     <string name="wind_direction_north">N</string>
     <string name="wind_direction_north_north_east">NNO</string>
     <string name="wind_direction_north_east">NO</string>
@@ -101,8 +134,8 @@
     <string name="wind_direction_west_north_west">WNW</string>
     <string name="wind_direction_north_west">NW</string>
     <string name="wind_direction_north_north_west">NNW</string>
-    <string name="msg_too_many_requests">Zu viele Anfragen. Bitte erneut versuchen.</string>
 
+    <!-- Wind strength - Beaufort -->
     <string name="beaufort_calm">Windstille</string>
     <string name="beaufort_light_air">Leiser Zug</string>
     <string name="beaufort_light_breeze">Leichte Brise</string>
@@ -117,31 +150,44 @@
     <string name="beaufort_violent_storm">Orkanartiger Sturm</string>
     <string name="beaufort_hurricane">Orkan</string>
 
-    <string name="uvi_no_info">Keine Daten</string>
-    <string name="uvi_low">Niedrig</string>
-    <string name="uvi_high">Hoch</string>
-    <string name="uvi_extreme">Extrem</string>
-    <string name="uvi_moderate">Mäßig</string>
-    <string name="uvi_very_high">Sehr hoch</string>
-
+    <!-- Dash clock -->
     <!-- 1: temperature; 2: unit -->
     <string name="dash_clock_status">%1$s%2$s</string>
     <!-- 1: temperature; 2: unit; 3: weather description -->
     <string name="dash_clock_expanded_title">%1$s%2$s - %3$s</string>
     <!-- 1: city; 2: country; 3: wind; 4: speed units; 5: pressure; 6: pressure units; 7: humidity -->
     <string name="dash_clock_expanded_body">%1$s, %2$s\nWind: %3$s %4$s\nLuftdruck: %5$s %6$s\nFeuchtigkeit: %7$s %%\n</string>
-    <string name="settings_title_units">Einheiten</string>
-    <string name="settings_title_display">Anzeige</string>
-    <string name="settings_title_data">Daten</string>
-    <string name="setting_displayDecimalZeroes">Zeige Null nach Komma</string>
+
+    <!-- Location -->
     <string name="settings_title_location">Ort</string>
     <string name="setting_update_location_automatically">Ort im Hintergrund aktualisieren</string>
-
     <string name="location_settings">Standorteinstellungen</string>
     <string name="location_settings_message">Standortdienste sind deaktiviert. Zu Systemeinstellungen wechseln?</string>
     <string name="location_settings_button">Einstellungen</string>
+
+    <!-- Map -->
     <string name="action_weather_map">Wetterkarte</string>
     <string name="rain">Niederschlag</string>
     <string name="temperature">Temperatur</string>
+    <string name="clouds">Bewölkung</string>
+
+    <!-- Graphs -->
     <string name="action_graphs">Diagramme</string>
+
+    <!-- About dialogue -->
+    <string name="about_unknown">Version unbekannt</string>
+    <string name="about_description">Eine leichtgewichtige freie Wetter-App, veröffentlicht unter der GPL3 Lizenz.</string>
+    <string name="about_developers">Entwickelt von <a href='mailto:t.martykan@gmail.com'>Tomáš Martykán</a> und <a href='https://github.com/martykan/forecastie/graphs/contributors'>anderen</a>, mit Unterstützung von <a href='https://github.com/martykan/forecastie/issues?utf8=✓;q=is%3Aissue'>vielen mehr</a>.</string>
+    <string name="about_src">Der Code ist verfügbar auf <a href='https://github.com/martykan/forecastie'>Github</a>.</string>
+    <string name="about_issues">Fehler und Verbesserungsvorschläge können auf unserer <a href='https://github.com/martykan/forecastie/issues'>Github Issues Seite</a> gemeldet werden.</string>
+    <string name="about_data">Daten sind bereitgestellt von <a href='https://openweathermap.org/'>OpenWeatherMap</a>, unter der <a href='http://creativecommons.org/licenses/by-sa/2.0/'>Creative Commons CC-BY-SA 2.0 Lizenz</a>.</string>
+    <string name="about_icons">Die Icons sind <a href='https://erikflowers.github.io/weather-icons/'>Weather Icons</a>, von <a href='http://www.twitter.com/artill'>Lukas Bischoff</a> und <a href='http://www.twitter.com/Erik_UX'>Erik Flowers</a>, unter der <a href='http://scripts.sil.org/OFL'>SIL OFL 1.1</a> Lizenz.</string>
+
+    <!-- Widget -->
+    <string name="widget_label_extensive">Ausführlich</string>
+    <string name="widget_label_time">Zeit</string>
+    <string name="widget_label_simple">Einfach</string>
+    <string name="widget_label_classic">Klassisch</string>
+
+    <string name="tap_for_graphs">Für Diagramme antippen</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -36,8 +36,6 @@
     <string name="setting_dateFormatCustom_summary">Δώστε την προσαρμοσμένη ημερομηνία σε μορφή SimpleDateFormat</string>
 
     <string name="setting_simple_string_formatting_intro">Τα παρακάτω σύμβολα μπορούν να χρησιμοποιηθούν για τον ορισμό μιας προσαρμοσμένης μορφής ημερομηνίας και ώρας</string>
-    <string name="setting_available_simple_string_codes">yYMwWDdFEuaHkKhmsSzZX</string>
-    <string name="setting_example_simple_string">EEEE, d MMM yyyy h:mm:ss a, zzzz</string>
     <string name="setting_example_date_format">Τετάρτη, 4 Ιουλ 2001 12:08:32 ΜΜ, Θερινή Ώρα Ειρηνικού</string>
 
     <string name="setting_lengthUnits">Μονάδες μήκους</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -108,8 +108,6 @@
     <string name="setting_dateFormatCustom">Formato de fecha personalizado</string>
     <string name="setting_dateFormatCustom_summary">Elija la cadena SimpleDateFormat personalizada a utilizar</string>
     <string name="setting_simple_string_formatting_intro">Puede usar los siguientes códigos para construir un formato de fecha y hora personalizado</string>
-    <string name="setting_available_simple_string_codes">yYMwWDdFEuaHkKhmsSzZX</string>
-    <string name="setting_example_simple_string">EEEE, d MMM yyyy h:mm:ss a, zzzz</string>
     <string name="setting_example_date_format">Miércoles, 4 Jul 2001 12:08:32 PM, Tiempo del Pacífico con horario de verano</string>
     <string name="dialog_ok">Aceptar</string>
     <string name="dialog_cancel">Cancelar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,8 +108,8 @@
     <string name="setting_dateFormatCustom">Custom Date Format</string>
     <string name="setting_dateFormatCustom_summary">Provide the custom SimpleDateFormat string to be used</string>
     <string name="setting_simple_string_formatting_intro">The codes below can be used to construct a custom date and time format</string>
-    <string name="setting_available_simple_string_codes">yYMwWDdFEuaHkKhmsSzZX</string>
-    <string name="setting_example_simple_string">EEEE, d MMM yyyy h:mm:ss a, zzzz</string>
+    <string name="setting_available_simple_string_codes" translatable="false">yYMwWDdFEuaHkKhmsSzZX</string>
+    <string name="setting_example_simple_string" translatable="false">EEEE, d MMM yyyy h:mm:ss a, zzzz</string>
     <string name="setting_example_date_format">Wednesday, 4 Jul 2001 12:08:32 PM, Pacific Daylight Time</string>
     <string name="dialog_ok">OK</string>
     <string name="dialog_cancel">Cancel</string>
@@ -224,5 +224,6 @@
     <string name="widget_label_time">Forecastie Time</string>
     <string name="widget_label_simple">Forecastie Simple</string>
     <string name="widget_label_classic">Forecastie Classic</string>
-    <string name ="tap_for_graphs">Tap for Graphs</string>
+
+    <string name="tap_for_graphs">Tap for Graphs</string>
 </resources>


### PR DESCRIPTION
- German translation complete and reordered according to default `strings.xml`
- marked simple date format code as not translatable (it makes no sense to translate `EEEE, d MMM yyyy h:mm:ss a, zzzz` to another language)