### PR TITLE
Add another short timestamp display format preset

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -111,6 +111,7 @@
         <item>E MM/dd/yyyy - hh:mm a</item>
         <item>EEEE, MMMM d, h:mma</item>
         <item>MM/dd/yyyy - hh:mm a</item>
+        <item>EEEE, HH:mm</item>
         <item>custom</item>
     </string-array>
 


### PR DESCRIPTION
Hi there,

first off: I've been using your app for quite a while now and find it convenient and useful; thanks for your work!
I was using the Play store version and was about to fork and implement a few features myself, including the ability to change the timestamp display format and customizable graphs.
Then, I noticed that the Play store version is way old. I've tested your latest code and found everything I've desired already in place :) Way to go!

So, here comes my humble little addition which I found the appropriate display format to include as a preset by default for everyone desiring a very simple timestamp format and not wanting to fiddle around with SDF strings.

Cheers