### PR TITLE
change error message for http errors

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/tasks/GenericRequestTask.java
+++ b/app/src/main/java/cz/martykan/forecastie/tasks/GenericRequestTask.java
@@ -102,8 +102,8 @@ public abstract class GenericRequestTask extends AsyncTask<String, String, TaskO
                     output.taskResult = TaskResult.TOO_MANY_REQUESTS;
                 } else {
                     // Bad response from server
-                    Log.w("Task", "bad response " + urlConnection.getResponseCode());
-                    output.taskResult = TaskResult.BAD_RESPONSE;
+                    Log.w("Task", "http error " + urlConnection.getResponseCode());
+                    output.taskResult = TaskResult.HTTP_ERROR;
                 }
             } catch (IOException e) {
                 Log.e("IOException Data", response);
@@ -154,8 +154,8 @@ public abstract class GenericRequestTask extends AsyncTask<String, String, TaskO
             case INVALID_API_KEY:
                 Snackbar.make(activity.findViewById(android.R.id.content), context.getString(R.string.msg_invalid_api_key), Snackbar.LENGTH_LONG).show();
                 break;
-            case BAD_RESPONSE:
-                Snackbar.make(activity.findViewById(android.R.id.content), context.getString(R.string.msg_connection_problem), Snackbar.LENGTH_LONG).show();
+            case HTTP_ERROR:
+                Snackbar.make(activity.findViewById(android.R.id.content), context.getString(R.string.msg_http_error), Snackbar.LENGTH_LONG).show();
                 break;
             case IO_EXCEPTION:
                 Snackbar.make(activity.findViewById(android.R.id.content), context.getString(R.string.msg_connection_not_available), Snackbar.LENGTH_LONG).show();

--- a/app/src/main/java/cz/martykan/forecastie/tasks/TaskResult.java
+++ b/app/src/main/java/cz/martykan/forecastie/tasks/TaskResult.java
@@ -1,3 +1,3 @@
 package cz.martykan.forecastie.tasks;
 
-public enum TaskResult { SUCCESS, BAD_RESPONSE, IO_EXCEPTION, TOO_MANY_REQUESTS, INVALID_API_KEY; }
+public enum TaskResult { SUCCESS, HTTP_ERROR, IO_EXCEPTION, TOO_MANY_REQUESTS, INVALID_API_KEY; }

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -82,7 +82,6 @@
     <string name="dialog_cancel">Скасаваць</string>
 
     <string name="msg_err_parsing_json">Памылка разбору JSON.</string>
-    <string name="msg_connection_problem">Праблемы з інтэрнэт-злучэннем.</string>
     <string name="msg_connection_not_available">Інтэрнэт-злучэнне недаступна.</string>
     <string name="msg_city_not_found">Указаны населены пункт не знойдзены.</string>
 

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -78,7 +78,6 @@
     <string name="dialog_cancel">Отказ</string>
 
     <string name="msg_err_parsing_json">Грешка при JSON парсване.</string>
-    <string name="msg_connection_problem">Има проблем с интернет връзката Ви.</string>
     <string name="msg_connection_not_available">Няма налична връзка.</string>
     <string name="msg_city_not_found">Посоченият град не е открит.</string>
 

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -78,7 +78,6 @@
     <string name="dialog_cancel">Cancel·lar</string>
 
     <string name="msg_err_parsing_json">Error en analitzar JSON.</string>
-    <string name="msg_connection_problem">Hi ha un problema amb la connexió a Internet.</string>
     <string name="msg_connection_not_available">Connexió no disponible.</string>
     <string name="msg_city_not_found">No s\'ha trobat la ciutat especificada.</string>
 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -44,7 +44,6 @@
     <string name="msg_err_parsing_json">Chyba čtení JSON.</string>
     <string name="msg_connection_not_available">Připojení není k dispozici.</string>
     <string name="msg_city_not_found">Město nebylo nalezeno.</string>
-    <string name="msg_connection_problem">Je tu problém s Vaším připojením.</string>
     <string name="pressure_unit_hpa">hPa</string>
     <string name="pressure_unit_kpa">kPa</string>
     <string name="pressure_unit_mmhg">mm Hg</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -116,7 +116,6 @@
 
     <!-- Errors -->
     <string name="msg_err_parsing_json">Fejl i JSON fortolkning.</string>
-    <string name="msg_connection_problem">Der er problemer med internet forbindelse.</string>
     <string name="msg_connection_not_available">Forbindelse ikke tilgængelig.</string>
     <string name="msg_city_not_found">Angivet by ikke fundet.</string>
     <string name="msg_too_many_requests">For mange forspørgsler. Prøv igen.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -111,8 +111,8 @@
     <string name="dialog_cancel">Abbrechen</string>
 
     <!-- Errors -->
-    <string name="msg_err_parsing_json">Fehler beim Parsen von JSON</string>
-    <string name="msg_connection_problem">Es gibt ein Problem mit der Internetverbindung.</string>
+    <string name="msg_err_parsing_json">Fehler beim Parsen von JSON.</string>
+    <string name="msg_http_error">Fehler beim Abrufen oder Empfangen der Daten.</string>
     <string name="msg_connection_not_available">Keine Verbindung</string>
     <string name="msg_city_not_found">Stadt konnte nicht gefunden werden.</string>
     <string name="msg_too_many_requests">Zu viele Anfragen. Bitte erneut versuchen.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -101,7 +101,6 @@
     <string name="dialog_cancel">Ακύρωση</string>
 
     <string name="msg_err_parsing_json">Σφάλμα ανάγνωσης JSON.</string>
-    <string name="msg_connection_problem">Πρόβλημα στην σύνδεση με το ίντερνετ.</string>
     <string name="msg_connection_not_available">Η σύνδεση δεν είναι διαθέσιμη.</string>
     <string name="msg_city_not_found">Δεν βρέθηκε η πόλη.</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -114,7 +114,6 @@
 
     <!-- Errors -->
     <string name="msg_err_parsing_json">Error al analizar JSON.</string>
-    <string name="msg_connection_problem">Hay un problema con su conexión a Internet.</string>
     <string name="msg_connection_not_available">Conexión no disponible.</string>
     <string name="msg_city_not_found">No se encuentra la ciudad especificada.</string>
     <string name="msg_too_many_requests">Demasiadas solicitudes. Inténtelo más tarde.</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -78,7 +78,6 @@
     <string name="dialog_cancel">Utzi</string>
 
     <string name="msg_err_parsing_json">Akatsa JSON irakurtzerakoan.</string>
-    <string name="msg_connection_problem">Arazo bat dago zure interneteko konexioarekin.</string>
     <string name="msg_connection_not_available">Konexioa ez dago eskuragarri.</string>
     <string name="msg_city_not_found">Zehaztutako hiria ez da aurkitu.</string>
 

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -68,7 +68,6 @@
     <string name="dialog_cancel">لغو</string>
 
     <string name="msg_err_parsing_json">خطا در تفسیر فرمت</string>
-    <string name="msg_connection_problem">مشکلی در ارتباط اینترنت شما وجود دارد.</string>
     <string name="msg_connection_not_available">ارتباطی در دسترسی نیست.</string>
     <string name="msg_city_not_found">شهر مورد مظر وجود ندارد.</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -116,7 +116,6 @@
 
     <!-- Errors -->
     <string name="msg_err_parsing_json">Erreur d\'analyse JSON.</string>
-    <string name="msg_connection_problem">Il y a un problème avec votre connexion à Internet.</string>
     <string name="msg_connection_not_available">Aucune connexion.</string>
     <string name="msg_city_not_found">Ville introuvable.</string>
     <string name="msg_too_many_requests">Trop de requêtes. Veuillez réessayer.</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -79,7 +79,6 @@ Pembaruan terakhir: %s</string>
     <string name="dialog_cancel">Batalkan</string>
 
     <string name="msg_err_parsing_json">Galat menguraikan JSON.</string>
-    <string name="msg_connection_problem">Ada masalah dengan koneksi internet Anda.</string>
     <string name="msg_connection_not_available">Koneksi tidak tersedia.</string>
     <string name="msg_city_not_found">Kota yang dispesifik tidak tersedia.</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -85,7 +85,6 @@
     <string name="dialog_cancel">Annulla</string>
 
     <string name="msg_err_parsing_json">Errore durante l\'analisi del file JSON.</string>
-    <string name="msg_connection_problem">C\'è un problema con la connessione Internet.</string>
     <string name="msg_connection_not_available">Connessione non disponibile.</string>
     <string name="msg_city_not_found">Città non trovata.</string>
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -78,7 +78,6 @@
     <string name="dialog_cancel">キャンセル</string>
 
     <string name="msg_err_parsing_json">JSON 解析エラー。</string>
-    <string name="msg_connection_problem">インターネット接続に問題があります。</string>
     <string name="msg_connection_not_available">接続が利用できません。</string>
     <string name="msg_city_not_found">指定した都市が見つかりません。</string>
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -96,7 +96,6 @@
     <string name="dialog_cancel">취소</string>
 
     <string name="msg_err_parsing_json">JSON 구문 분석 오류</string>
-    <string name="msg_connection_problem">인터넷 연결에 문제가 있습니다</string>
     <string name="msg_connection_not_available">접속불가</string>
     <string name="msg_city_not_found">지정된 도시를 찾을 수 없습니다</string>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -78,7 +78,6 @@
     <string name="dialog_cancel">Annuleren</string>
 
     <string name="msg_err_parsing_json">Fout bij verwerken van JSON.</string>
-    <string name="msg_connection_problem">Er is een probleem met je internetverbinding.</string>
     <string name="msg_connection_not_available">Verbinding niet beschikbaar.</string>
     <string name="msg_city_not_found">De opgegeven stad kan niet worden gevonden.</string>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -78,7 +78,6 @@
     <string name="dialog_cancel">Anuluj</string>
 
     <string name="msg_err_parsing_json">Błąd parsowania JSON</string>
-    <string name="msg_connection_problem">Brak połączenia z internetem</string>
     <string name="msg_connection_not_available">Brak połączenia</string>
     <string name="msg_city_not_found">Nie można odnaleźć miasta</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -78,7 +78,6 @@
     <string name="dialog_cancel">Cancelar</string>
 
     <string name="msg_err_parsing_json">Erro ao analisar JSON.</string>
-    <string name="msg_connection_problem">Há um problema com a sua conexão à Internet.</string>
     <string name="msg_connection_not_available">Conexão indisponível.</string>
     <string name="msg_city_not_found">A cidade especificada não foi encontrada.</string>
 

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -78,7 +78,6 @@
     <string name="dialog_cancel">Cancelar</string>
 
     <string name="msg_err_parsing_json">Erro ao analisar JSON.</string>
-    <string name="msg_connection_problem">Existe um problema com a sua ligação à Internet.</string>
     <string name="msg_connection_not_available">Ligação não disponível.</string>
     <string name="msg_city_not_found">A cidade que especificou não foi encontrada.</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -78,7 +78,6 @@
     <string name="dialog_cancel">Отмена</string>
 
     <string name="msg_err_parsing_json">Ошибка разбора JSON.</string>
-    <string name="msg_connection_problem">Проблемы с интернет-соединением.</string>
     <string name="msg_connection_not_available">Интернет-соединение отсутствует.</string>
     <string name="msg_city_not_found">Указанный населённый пункт не найден.</string>
 

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -89,7 +89,6 @@
     <string name="dialog_cancel">Avbryt</string>
 
     <string name="msg_err_parsing_json">Fel vid parsning av JSON.</string>
-    <string name="msg_connection_problem">Det finns ett problem med din internets anslutning.</string>
     <string name="msg_connection_not_available">Anslutning inte tillgänglig.</string>
     <string name="msg_city_not_found">Den angivna staden hittades inte.</string>
 

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -78,7 +78,6 @@
     <string name="dialog_cancel">Storno</string>
 
     <string name="msg_err_parsing_json">Chyba čítania JSON.</string>
-    <string name="msg_connection_problem">Je tu problém s Vaším internetovým pripojením.</string>
     <string name="msg_connection_not_available">Pripojenie nie je k dispozícii.</string>
     <string name="msg_city_not_found">Zadané mesto nebolo nájdené.</string>
 

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -35,7 +35,6 @@
     <string name="location_settings_message">Није омогућено лоцирање у подешавањима уређаја. Желите ли да отворите подешавања?</string>
     <string name="msg_city_not_found">Захтевано место није пронађено.</string>
     <string name="msg_connection_not_available">Веза није доступна.</string>
-    <string name="msg_connection_problem">Постоји проблем са Интернет везом.</string>
     <string name="msg_err_parsing_json">Грешка у преузимању JSON.</string>
     <string name="msg_too_many_requests">Превише захтева. Молимо покушајте поново.</string>
     <string name="pressure">Притисак</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -78,7 +78,6 @@
     <string name="dialog_cancel">İptal</string>
 
     <string name="msg_err_parsing_json">JSON ayrıştırılma hatası.</string>
-    <string name="msg_connection_problem">İnternet bağlantınızda problem var.</string>
     <string name="msg_connection_not_available">Bağlantı uygun değil.</string>
     <string name="msg_city_not_found">Belirtilen şehir bulunamadı.</string>
 

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -78,7 +78,6 @@
     <string name="dialog_cancel">Скасувати</string>
 
     <string name="msg_err_parsing_json">Помилка розбору JSON.</string>
-    <string name="msg_connection_problem">Виникла проблема з підключенням до інтернету.</string>
     <string name="msg_connection_not_available">Підключення недоступне.</string>
     <string name="msg_city_not_found">Вказане місто не знайдено.</string>
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -78,7 +78,6 @@
     <string name="dialog_cancel">取消</string>
 
     <string name="msg_err_parsing_json">JSOM解析错误。</string>
-    <string name="msg_connection_problem">网络连接出错。</string>
     <string name="msg_connection_not_available">连接不可用。</string>
     <string name="msg_city_not_found">没有找到该城市。</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,7 +116,7 @@
 
     <!-- Errors -->
     <string name="msg_err_parsing_json">Error parsing JSON.</string>
-    <string name="msg_connection_problem">There is a problem with your internet connection.</string>
+    <string name="msg_http_error">Error while requesting or receiving data.</string>
     <string name="msg_connection_not_available">Connection not available.</string>
     <string name="msg_city_not_found">Specified city is not found.</string>
     <string name="msg_too_many_requests">Too many requests. Please try again.</string>


### PR DESCRIPTION
- change / straighten error message for HTTP errors
- change string name from `msg_connection_problem` to `msg_http_error` and remove the string from most languages because a untranslated but correct error message might be more helpful than an incorrect error message