### PR TITLE
allow simple widget to be resized

### DIFF
--- a/app/src/main/res/xml/simple_widget.xml
+++ b/app/src/main/res/xml/simple_widget.xml
@@ -4,7 +4,7 @@
     android:minHeight="50dp"
     android:updatePeriodMillis="1800000"
     android:initialLayout="@layout/simple_widget"
-    android:resizeMode="none"
+    android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen|keyguard"
     android:previewImage="@drawable/widget_preview_simple">
 </appwidget-provider>


### PR DESCRIPTION
This allow the small widget to fit/center better on screens with 5 columns

I can rework this to only allow horizontal resizing, if we want to keep the vertical size limited.