### PR TITLE
No need to manually refresh after choosing a location.

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/fragments/AmbiguousLocationDialogFragment.java
+++ b/app/src/main/java/cz/martykan/forecastie/fragments/AmbiguousLocationDialogFragment.java
@@ -156,7 +156,7 @@ public class AmbiguousLocationDialogFragment extends DialogFragment implements L
     public void onItemClickListener(View view, int position) {
         final Weather weather = recyclerAdapter.getItem(position);
         final Intent intent = new Intent(getActivity(), MainActivity.class);
-        intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+       
         final Bundle bundle = new Bundle();
 
         sharedPreferences.edit().putString("cityId", weather.getId()).commit();


### PR DESCRIPTION
Auto refreshes info in main screen every time user selects a location . 
Removed the intent flag from AmbiguousLocationDialogFragment.java , due to which a user had to manually refresh every time he/she chooses
 a location   .

#546 