### PR TITLE
Fix WeatherRepositoryTests

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/notifications/WeatherNotificationService.java
+++ b/app/src/main/java/cz/martykan/forecastie/notifications/WeatherNotificationService.java
@@ -18,6 +18,8 @@ import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.app.TaskStackBuilder;
 
+import java.util.concurrent.Executors;
+
 import cz.martykan.forecastie.R;
 import cz.martykan.forecastie.activities.MainActivity;
 import cz.martykan.forecastie.models.WeatherPresentation;
@@ -50,7 +52,7 @@ public class WeatherNotificationService extends Service {
 
         startForeground(WEATHER_NOTIFICATION_ID, notification.build());
 
-        repository = new WeatherRepository(this);
+        repository = new WeatherRepository(this, Executors.newSingleThreadExecutor());
         repositoryListener = new WeatherRepository.RepositoryListener() {
             @Override
             public void onChange(@NonNull WeatherPresentation newData) {

--- a/app/src/main/java/cz/martykan/forecastie/notifications/repository/WeatherRepository.java
+++ b/app/src/main/java/cz/martykan/forecastie/notifications/repository/WeatherRepository.java
@@ -14,7 +14,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
 import cz.martykan.forecastie.R;
@@ -35,13 +34,14 @@ public class WeatherRepository {
     private String typeSimpleKey;
     private String typeDefault;
 
-    private final Executor executor = Executors.newSingleThreadExecutor();
+    private final Executor executor;
     private SharedPreferences prefs;
     private final Set<WeakReference<RepositoryListener>> listeners = new HashSet<>();
     private SharedPreferences.OnSharedPreferenceChangeListener onSharedPreferenceChangeListener;
     private final AtomicReference<WeatherPresentation> weatherPresentation = new AtomicReference<>();
 
-    public WeatherRepository(@NonNull Context context) {
+    public WeatherRepository(@NonNull Context context, @NonNull Executor executor) {
+        this.executor = executor;
         prepareSettingsConstants(context);
         prefs = PreferenceManager.getDefaultSharedPreferences(context);
     }


### PR DESCRIPTION
Replace `Thread.sleep` with `PausedExecutorService` for executing `Runnables` on background threads.