### PR TITLE
Fix percentage typo on precipitation

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/utils/UnitConvertor.java
+++ b/app/src/main/java/cz/martykan/forecastie/utils/UnitConvertor.java
@@ -61,7 +61,7 @@ public class UnitConvertor {
             }
 
             if (percentOfPrecipitation > 0) {
-                sb.append(", ").append(String.format(Locale.ENGLISH, "%d%%", (int) (percentOfPrecipitation * 100)));
+                sb.append(", ").append(String.format(Locale.ENGLISH, "%d%%", Math.round(percentOfPrecipitation * 100)));
             }
 
             sb.append(")");


### PR DESCRIPTION
```java
String.format(Locale.ENGLISH, "%d%%", (int) (percentOfPrecipitation * 100)
```

In this code, if `percentOfPrecipitation` is `0.58`, the result will be `57%`. 
Using `Math.round` can solve this problem.