### PR TITLE
Replace loadUrl("javascript:...") with evaluateJavascript in MapActivity

### DIFF
--- a/app/src/main/java/cz/martykan/forecastie/activities/MapActivity.java
+++ b/app/src/main/java/cz/martykan/forecastie/activities/MapActivity.java
@@ -78,17 +78,17 @@ public class MapActivity extends BaseActivity {
 
     private void setMapState(int item) {
         if (item == R.id.map_clouds) {
-            webView.loadUrl("javascript:map.removeLayer(rainLayer);map.removeLayer(windLayer);map.removeLayer(tempLayer);"
-                    + "map.addLayer(cloudsLayer);");
+            webView.evaluateJavascript("map.removeLayer(rainLayer);map.removeLayer(windLayer);map.removeLayer(tempLayer);"
+                    + "map.addLayer(cloudsLayer);", null);
         } else if (item == R.id.map_rain) {
-            webView.loadUrl("javascript:map.removeLayer(cloudsLayer);map.removeLayer(windLayer);map.removeLayer(tempLayer);"
-                    + "map.addLayer(rainLayer);");
+            webView.evaluateJavascript("map.removeLayer(cloudsLayer);map.removeLayer(windLayer);map.removeLayer(tempLayer);"
+                    + "map.addLayer(rainLayer);", null);
         } else if (item == R.id.map_wind) {
-            webView.loadUrl("javascript:map.removeLayer(cloudsLayer);map.removeLayer(rainLayer);map.removeLayer(tempLayer);"
-                    + "map.addLayer(windLayer);");
+            webView.evaluateJavascript("map.removeLayer(cloudsLayer);map.removeLayer(rainLayer);map.removeLayer(tempLayer);"
+                    + "map.addLayer(windLayer);", null);
         } else if (item == R.id.map_temperature) {
-            webView.loadUrl("javascript:map.removeLayer(cloudsLayer);map.removeLayer(windLayer);map.removeLayer(rainLayer);"
-                    + "map.addLayer(tempLayer);");
+            webView.evaluateJavascript("map.removeLayer(cloudsLayer);map.removeLayer(windLayer);map.removeLayer(rainLayer);"
+                    + "map.addLayer(tempLayer);", null);
         } else {
             Log.w("MapActivity", "Layer not configured");
         }


### PR DESCRIPTION
Closes #717.

`MapActivity.setMapState` used the legacy `webView.loadUrl("javascript:...")` form to toggle weather overlays on the OpenWeatherMap WebView. The Android docs deprecated that pattern in KitKat in favour of `evaluateJavascript`:

- The legacy form adds a navigation entry to the WebView back stack, so flipping between cloud / rain / wind / temperature layers pollutes the back history of MapActivity.
- It cannot return a value (irrelevant here, but the reason the platform moved on).

### Change

Swap the four call sites in `setMapState` to `webView.evaluateJavascript(script, null)`. The visible behaviour (overlay change) is unchanged. The back stack stays clean.
